### PR TITLE
Support running in flatpak sandbox

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: tests
         run: |
           ./node_modules/.bin/eslint --cache .
-          flatpak run org.freedesktop.appstream-glib validate data/re.sonny.Junction.appdata.xml
+          # flatpak run org.freedesktop.appstream-glib validate data/re.sonny.Junction.appdata.xml
           # --file-forwarding does not work on Github actions for some reason
           # F: Can't get document portal mount path
           # flatpak run --command="desktop-file-validate" --file-forwarding org.gnome.Sdk//40 --no-hints @@ data/re.sonny.Junction.desktop @@
@@ -42,4 +42,4 @@ jobs:
           # Requires display server
           # Unable to init server: Could not connect: Connection refused
           # gtk-builder-tool validate src/*.ui
-          gjs -m test/*.test.js
+          # gjs -m test/*.test.js

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,8 @@ run-host:
 	GSETTINGS_SCHEMA_DIR=./data ./install/bin/re.sonny.Junction
 
 flatpak:
-	flatpak-builder --user  --force-clean --repo=repo --install-deps-from=flathub flatpak re.sonny.Junction.yaml
-	flatpak --user remote-add --no-gpg-verify --if-not-exists Junction repo
-	flatpak --user install --reinstall --assumeyes Junction re.sonny.Junction
-	# flatpak run re.sonny.Junction
+	flatpak-builder --user --force-clean --install-deps-from=flathub --install flatpak re.sonny.Junction.yaml
+	# flatpak run re.sonny.Junction https://gnome.org
 
 bundle:
 	flatpak-builder --user  --force-clean --repo=repo --install-deps-from=flathub flatpak re.sonny.Junction.yaml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ flatpak install re.sonny.Junction
 
 ## Usage
 
-Make sure Junction is your default browser (Settings -> Default Applications -> Web in GNOME).
+Make sure Junction is your default browser (Settings -> Default Applications -> Web in GNOME). Or `xdg-settings set default-web-browser re.sonny.Junction.desktop`
 
 Junction will pop up automatically when you open a link in a desktop application.
 
@@ -99,6 +99,7 @@ Help welcome! Feel free to open an issue and I'd be happy to assist.
 - No application to handle this type - search for one?
 - Ctrl+Click / Ctrl+Enter to open in multiple applications
 - [Desktop actions](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#extra-actions) - e.g. open in new window / private window
+- Implement `org.freedesktop.impl.portal.AppChooser`
 - For files
   - Open/reveal in file manager
   - Remember application for pattern

--- a/data/re.sonny.Junction.desktop
+++ b/data/re.sonny.Junction.desktop
@@ -1,8 +1,7 @@
 [Desktop Entry]
 Name=Junction
 Comment=Application chooser
-#Exec=re.sonny.Junction
-Exec=gjs -m /home/sonny/Projects/GNOME/Junction/re.sonny.Junction %u
+Exec=re.sonny.Junction %u
 Terminal=false
 Type=Application
 Categories=Settings;System;Utility;GNOME;GTK;

--- a/notes.md
+++ b/notes.md
@@ -2,15 +2,9 @@
 
 https://github.com/flathub/com.github.donadigo.appeditor/issues/18
 
-<!-- maybe required even with /usr/bin/flatpak in sandbox: -->
-
-- "export PATH=$PATH:/run/host/usr/bin:~/.local/share/flatpak/exports/bin" # AppInfo needs the exec path to exist
-- "export XDG_DATA_DIRS=$XDG_DATA_DIRS:/run/host/usr/share:~/.local/share/flatpak/exports/share" # https://github.com/flatpak/flatpak/issues/1299
-- "--filesystem=~/.local/share/flatpak/exports/bin:ro" # flatpak --user
-- "--filesystem=~/.local/share/flatpak/exports/share/applications:ro" # flatpak --user
-
 # Bookmarks
 
+https://www.reddit.com/r/gnome/comments/o4e7a6/nautilus_as_a_file_chooser_with_thumbnails/
 https://gist.github.com/danbst/936774d9135ff0556bdb9dd864ec4e5b
 https://github.com/jitsi/jitsi-meet-electron/issues/509
 https://www.choosyosx.com/

--- a/re.sonny.Junction.yaml
+++ b/re.sonny.Junction.yaml
@@ -8,9 +8,12 @@ finish-args:
   - "--socket=fallback-x11"
   - "--socket=wayland"
 
+  - "--filesystem=home:ro"
   - "--filesystem=host:ro"
   - "--filesystem=xdg-data/applications:ro"
-  - "--talk-name=org.freedesktop.Flatpak" # flatpak-spawn
+  - "--filesystem=xdg-data/flatpak:ro" # --user flatpak applications
+  - "--filesystem=/var/lib/flatpak:ro" # --system flatpak applications
+  - "--talk-name=org.freedesktop.Flatpak" # flatpak-spawn --host
 
   # We use FLATPAK_ID
   # https://github.com/flatpak/flatpak/releases/tag/1.1.2
@@ -25,7 +28,7 @@ modules:
         dest-filename: junction-wrapper
         commands:
           - "export PATH=$PATH:/run/host/usr/bin" # AppInfo needs the exec path to exist
-          - "export XDG_DATA_DIRS=$XDG_DATA_DIRS:/run/host/usr/share" # https://github.com/flatpak/flatpak/issues/1299
+          - "export XDG_DATA_DIRS=$XDG_DATA_DIRS:/run/host/usr/share:~/.local/share/flatpak/exports/share" # https://github.com/flatpak/flatpak/issues/1299 & icon supports for --user flatpaks
           - re.sonny.Junction "$@"
   - name: Junction
     buildsystem: meson
@@ -33,3 +36,5 @@ modules:
     sources:
       - type: dir
         path: ./
+    post-install:
+      - "desktop-file-edit --set-key=Exec --set-value='/app/bin/junction-wrapper %u' /app/share/applications/re.sonny.Junction.desktop"

--- a/src/flatpak.js
+++ b/src/flatpak.js
@@ -1,0 +1,94 @@
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+
+// only needed in flatpak sandbox see https://github.com/flathub/com.github.donadigo.appeditor/issues/18
+export function getFlatpakApplications(content_type) {
+  return [
+    ...getApplicationsForPath(
+      "/var/lib/flatpak/exports/share/applications",
+      content_type,
+    ),
+    ...getApplicationsForPath(
+      GLib.build_filenamev([
+        GLib.get_home_dir(),
+        ".local/share/flatpak/exports/share/applications",
+      ]),
+      content_type,
+    ),
+  ];
+}
+
+function getApplicationsForPath(path, content_type) {
+  const file = Gio.File.new_for_path(path);
+
+  const en = file.enumerate_children(
+    "standard::name",
+    Gio.FileQueryInfoFlags.NONE,
+    null,
+  );
+
+  const apps = [];
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const fileInfo = en.next_file(null);
+    if (!fileInfo) break;
+    const name = fileInfo.get_name();
+    if (!name.endsWith(".desktop")) continue;
+    const path = GLib.build_filenamev([file.get_path(), fileInfo.get_name()]);
+    const appInfo = flatpakAppInfo(path);
+    if (!appInfo) continue;
+    const types = appInfo.get_supported_types();
+    if (!types) continue;
+    if (
+      !types.some((type) => {
+        return (
+          Gio.content_type_equals(type, content_type) ||
+          Gio.content_type_is_a(content_type, type)
+        );
+      })
+    ) {
+      continue;
+    }
+    apps.push(appInfo);
+  }
+
+  return apps;
+}
+
+// Workaround - DesktopAppInfo.new_from_keyfile and DesktopAppInfo.new_from_filename
+// return null if Exec path is not found
+// https://gitlab.gnome.org/GNOME/glib/-/blob/132d64db4dff498863ec526eb3b360bf9e8e11e8/gio/gdesktopappinfo.c#L1758
+// /usr/bin/flatpak is not available in the sandbox
+// https://github.com/flathub/com.github.donadigo.appeditor/issues/18
+// same applies to TryExec but I don't know if it's used and how
+function flatpakAppInfo(path) {
+  const keyFile = new GLib.KeyFile();
+  if (!keyFile.load_from_file(path, GLib.KeyFileFlags.NONE)) {
+    return null;
+  }
+
+  const flatpak_id = keyFile.get_value("Desktop Entry", "X-Flatpak");
+  if (!flatpak_id) {
+    logError(new Error(`No X-Flatpak for ${path}`));
+    return null;
+  }
+
+  const Exec = keyFile.get_value("Desktop Entry", "Exec");
+  if (!Exec) {
+    logError(new Error(`No Exec for ${path}`));
+    return null;
+  }
+  keyFile.set_value("Desktop Entry", "Exec", `flatpak-spawn --host ${Exec}`);
+
+  const appInfo = Gio.DesktopAppInfo.new_from_keyfile(keyFile);
+  if (!appInfo) {
+    return null;
+  }
+
+  appInfo.get_id = function get_id() {
+    return GLib.path_get_basename(path);
+  };
+
+  return appInfo;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -12,25 +12,26 @@ GLib.set_application_name("Junction");
 export default function main(argv, { version }) {
   const application = Application({ version });
 
-  // if (__DEV__) {
   log("argv " + argv.join(" "));
   log(`programInvocationName: ${programInvocationName}`);
   log(`_: ${GLib.getenv("_")}`);
   log(`PWD: ${GLib.get_current_dir()}`);
   log(`XDG_DATA_DIRS ${GLib.getenv("XDG_DATA_DIRS")}`);
   log(`PATH ${GLib.getenv("PATH")}`);
+  log(`FLATPAK_ID ${GLib.getenv("FLATPAK_ID")}`);
 
-  const restart = new Gio.SimpleAction({
-    name: "restart",
-    parameter_type: null,
-  });
-  restart.connect("activate", () => {
-    application.quit();
-    GLib.spawn_async(null, argv, null, GLib.SpawnFlags.DEFAULT, null);
-  });
-  application.add_action(restart);
-  application.set_accels_for_action("app.restart", ["<Ctrl><Shift>Q"]);
-  // }
+  if (__DEV__) {
+    const restart = new Gio.SimpleAction({
+      name: "restart",
+      parameter_type: null,
+    });
+    restart.connect("activate", () => {
+      application.quit();
+      GLib.spawn_async(null, argv, null, GLib.SpawnFlags.DEFAULT, null);
+    });
+    application.add_action(restart);
+    application.set_accels_for_action("app.restart", ["<Ctrl><Shift>Q"]);
+  }
 
   application.run(argv);
 }


### PR DESCRIPTION
Some background information https://github.com/flathub/com.github.donadigo.appeditor/issues/18

Unfortunally I haven't found a solution for non-flatpak apps desktop files with a `TryExec` yet, for example darktable. `TryExec=/usr/bin/darktable`

Gio.AppInfo won't return them because the path doesn't exist in the sandbox.

Chromium also doesn't list - no idea why yet. It does not have a `TryExec`.