### PR TITLE
Fix broken formatting in metainfo file

### DIFF
--- a/data/re.sonny.Junction.metainfo.xml
+++ b/data/re.sonny.Junction.metainfo.xml
@@ -56,8 +56,9 @@
       </description>
     </release>
     <release version="1.0.0" date="2021-10-16">
-      <description
-      >This is the first release of Junction. We hope you like it.</description>
+      <description>
+        This is the first release of Junction. We hope you like it.
+      </description>
     </release>
   </releases>
   <kudos>


### PR DESCRIPTION
The broken formatting causes AppStream metadata to be broken - missing screenshot etc.