### PR TITLE
Add junction:// protocol

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ install/
 flatpak/
 node_modules/
 repo/
+test/uvu.js
+test/assert.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,14 +10,17 @@ globals:
   Intl: readonly
   imports: readonly
   pkg: readonly
-  log: readonly
-  logError: readonly
-  print: readonly
-  printerr: readonly
+  # log: readonly
+  # logError: readonly
+  # print: readonly
+  # printerr: readonly
   ARGV: readonly
   window: readonly
   globalThis: readonly
   __DEV__: readonly
+  console: readonly
+  TextEncoder: readonly
+  TextDecoder: readonly
 parserOptions:
   sourceType: module
 rules:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+package-lock.json -diff
+test/assert.js -diff
+test/uvu.js -diff

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ install/
 flatpak/
 node_modules/
 repo/
+test/assert.js
+test/uvu.js

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ test:
 	flatpak run org.freedesktop.appstream-glib validate data/re.sonny.Junction.metainfo.xml
 	flatpak run --command="desktop-file-validate" --file-forwarding org.gnome.Sdk//41 --no-hints @@ data/re.sonny.Junction.desktop @@
 	# gtk4-builder-tool validate src/*.ui
-	gjs -m test/*.test.js
 	flatpak-builder --show-manifest re.sonny.Junction.json
 	find po/ -type f -name "*.po" -print0 | xargs -0 -n1 msgfmt -o /dev/null --check
+	gjs -m test/*.test.js
 
 clean:
 	rm -rf build builddir install .eslintcache

--- a/README.md
+++ b/README.md
@@ -50,12 +50,24 @@ Please note that this may not be respected by all applications but the command `
   </code>
 </details>
 
-## Tips and tricks
+<details>
+  <summary>API</summary>
+
+Junction has a very simple API that doesn't require any programming. To open any resource with Junction, even if it's not configured as the default application, simply use the following URI format `x-junction://$RESOURCE`. For examples
+
+- `x-junction://https://github.com`
+- `x-junction://~`
+- `x-junction://file:///etc/os-release`
+- `x-junction:///etc/os-release`
+
+You can use this in web pages, the terminal, native applications and anything that is able to open URIs.
+
+If Junction is installed - you can test this in the terminal with `xdg-open "x-junction://file:///etc/os-release"` and in the browser with `<a href="x-junction://file:///etc/os-release">Test Junction URI</a>`.
 
 <details>
   <summary>Keyboard navigation</summary>
 
-Use the menu or `<Ctrl>?` to learn about Keyboard usage.
+Use the menu or `<Ctrl>?` to learn about Keyboard usage. You can navigate the UI with the arrow keys too.
 
 </details>
 
@@ -100,11 +112,17 @@ See https://wiki.archlinux.org/title/desktop_entries (distro agnostic).
 </details>
 
 <details>
-  <summary>Open links on a website with Junction</summary>
+  <summary>Browser integration</summary>
 
-If you want links on your favorite websites to open Junction, set it as the default browser and use [Tangram](https://github.com/sonnyp/Tangram/).
+Drag the following [bookmarklet](https://en.wikipedia.org/wiki/Bookmarklet) to your browser bookmarks toolbar to create a button to open the current page in Junction.
 
-A browser extension might be coming.
+Bookmarklet: <a herf="javascript:window.location='x-junction://'+window.location">Junction</a>
+
+Or create a bookmark with the following URL
+
+```
+javascript:window.location='x-junction://'+window.location
+```
 
 </details>
 

--- a/data/re.sonny.Junction.desktop
+++ b/data/re.sonny.Junction.desktop
@@ -3,6 +3,7 @@
 Name=Junction
 Comment=Application chooser
 Exec=re.sonny.Junction %U
+MimeType=x-scheme-handler/x-junction
 Terminal=false
 Type=Application
 Categories=Settings;System;Utility;GNOME;GTK;

--- a/data/re.sonny.Junction.metainfo.xml
+++ b/data/re.sonny.Junction.metainfo.xml
@@ -58,9 +58,10 @@
       <description>
         <ul>
           <li>Improve design</li>
+          <li>Add a x-juncton:// protocol API</li>
           <li
           >Do not automatically set Junction as default application for Web</li>
-          <li>Fix some options not available</li>
+          <li>Fix missing options</li>
           <li>Limit the number of options to 4</li>
           <li>Add an option to open with any application</li>
           <li>Add a System Information panel in the about dialog</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,121 +4,28 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "devDependencies": {
         "@prettier/plugin-xml": "^1.1.0",
-        "eslint": "^8.2.0",
+        "@rollup/plugin-node-resolve": "^13.0.6",
+        "eslint": "^8.4.1",
         "eslint-plugin-import": "^2.25.3",
         "husky": "^7.0.4",
-        "lint-staged": "^12.0.2",
-        "prettier": "^2.4.1"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "lint-staged": "^12.1.2",
+        "prettier": "^2.5.1",
+        "rollup": "^2.61.1",
+        "uvu": "^0.5.2"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
-      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
+      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.0.0",
+        "espree": "^9.2.0",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -131,12 +38,12 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
-      "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
+      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.0",
+        "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       },
@@ -160,17 +67,75 @@
         "prettier": ">=2.3"
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz",
+      "integrity": "sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.42.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+    "node_modules/@types/node": {
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@xml-tools/parser": {
       "version": "1.0.11",
@@ -182,9 +147,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -370,6 +335,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -502,22 +479,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -555,6 +516,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -565,6 +535,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -595,15 +583,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -657,23 +636,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/eslint": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
-      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.0.4",
-        "@humanwhocodes/config-array": "^0.6.0",
+        "@eslint/eslintrc": "^1.0.5",
+        "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -681,10 +651,10 @@
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^6.0.0",
+        "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.0.0",
-        "espree": "^9.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.2.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -818,9 +788,9 @@
       "dev": true
     },
     "node_modules/eslint-scope": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-      "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -879,14 +849,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-      "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.2.0.tgz",
+      "integrity": "sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.5.0",
+        "acorn": "^8.6.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.0.0"
+        "eslint-visitor-keys": "^3.1.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1291,12 +1261,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -1393,6 +1357,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
@@ -1515,12 +1485,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1532,12 +1496,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -1563,6 +1521,15 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1576,30 +1543,35 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+    "node_modules/lilconfig": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/lint-staged": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.0.2.tgz",
-      "integrity": "sha512-tpCvACqc7bykziGJmXG0G8YG2RaCrWiDBwmrP9wU7i/3za9JMOvCECQmXjw/sO4ICC70ApVwyqixS1htQX9Haw==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.2.tgz",
+      "integrity": "sha512-bSMcQVqMW98HLLLR2c2tZ+vnDCnx4fd+0QJBQgN/4XkdspGRPc8DGp7UuOEBe1ApCfJ+wXXumYnJmU+wDo7j9A==",
       "dev": true,
       "dependencies": {
-        "cli-truncate": "3.1.0",
+        "cli-truncate": "^3.1.0",
         "colorette": "^2.0.16",
         "commander": "^8.3.0",
-        "cosmiconfig": "^7.0.1",
         "debug": "^4.3.2",
+        "enquirer": "^2.3.6",
         "execa": "^5.1.1",
+        "lilconfig": "2.0.4",
         "listr2": "^3.13.3",
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
-        "object-inspect": "1.11.0",
-        "string-argv": "0.3.1",
-        "supports-color": "9.0.2"
+        "object-inspect": "^1.11.0",
+        "string-argv": "^0.3.1",
+        "supports-color": "^9.0.2",
+        "yaml": "^1.10.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -1892,6 +1864,15 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2079,24 +2060,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2129,15 +2092,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -2173,9 +2127,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -2270,6 +2224,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.61.1.tgz",
+      "integrity": "sha512-BbTXlEvB8d+XFbK/7E5doIcRtxWPRiqr0eb5vQ0+2paMM04Ye4PZY5nHOQef2ix24l/L0SpLd5hwcH15QHPdvA==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
@@ -2277,6 +2246,18 @@
       "dev": true,
       "dependencies": {
         "tslib": "~2.1.0"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+      "dev": true,
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/semver": {
@@ -2476,6 +2457,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/totalist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
@@ -2540,6 +2530,25 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.2.tgz",
+      "integrity": "sha512-m2hLe7I2eROhh+tm3WE5cTo/Cv3WQA7Oc9f7JB6uWv+/zVKvfAm53bMyOoGOSZeQ7Ov2Fu9pLhFr7p07bnT20w==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3",
+        "totalist": "^2.0.0"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -2628,93 +2637,15 @@
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.16.0"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true
-    },
-    "@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "@eslint/eslintrc": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
-      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
+      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.0.0",
+        "espree": "^9.2.0",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -2724,12 +2655,12 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
-      "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
+      "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
       "dev": true,
       "requires": {
-        "@humanwhocodes/object-schema": "^1.2.0",
+        "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
@@ -2750,17 +2681,65 @@
         "prettier": ">=2.3"
       }
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz",
+      "integrity": "sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+    "@types/node": {
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@xml-tools/parser": {
       "version": "1.0.11",
@@ -2772,9 +2751,9 @@
       }
     },
     "acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -2905,6 +2884,12 @@
         "fill-range": "^7.0.1"
       }
     },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3004,19 +2989,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
-      "dev": true,
-      "requires": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3043,6 +3015,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3051,6 +3029,18 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -3074,15 +3064,6 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -3124,20 +3105,14 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
     "eslint": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
-      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.4",
-        "@humanwhocodes/config-array": "^0.6.0",
+        "@eslint/eslintrc": "^1.0.5",
+        "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -3145,10 +3120,10 @@
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^6.0.0",
+        "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.0.0",
-        "espree": "^9.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.2.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3275,9 +3250,9 @@
       }
     },
     "eslint-scope": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-      "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
+      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -3308,14 +3283,14 @@
       "dev": true
     },
     "espree": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-      "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.2.0.tgz",
+      "integrity": "sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==",
       "dev": true,
       "requires": {
-        "acorn": "^8.5.0",
+        "acorn": "^8.6.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.0.0"
+        "eslint-visitor-keys": "^3.1.0"
       }
     },
     "esquery": {
@@ -3606,12 +3581,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -3675,6 +3644,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -3752,12 +3727,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3766,12 +3735,6 @@
       "requires": {
         "argparse": "^2.0.1"
       }
-    },
-    "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -3794,6 +3757,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3804,30 +3773,32 @@
         "type-check": "~0.4.0"
       }
     },
-    "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+    "lilconfig": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
+      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
       "dev": true
     },
     "lint-staged": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.0.2.tgz",
-      "integrity": "sha512-tpCvACqc7bykziGJmXG0G8YG2RaCrWiDBwmrP9wU7i/3za9JMOvCECQmXjw/sO4ICC70ApVwyqixS1htQX9Haw==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.2.tgz",
+      "integrity": "sha512-bSMcQVqMW98HLLLR2c2tZ+vnDCnx4fd+0QJBQgN/4XkdspGRPc8DGp7UuOEBe1ApCfJ+wXXumYnJmU+wDo7j9A==",
       "dev": true,
       "requires": {
-        "cli-truncate": "3.1.0",
+        "cli-truncate": "^3.1.0",
         "colorette": "^2.0.16",
         "commander": "^8.3.0",
-        "cosmiconfig": "^7.0.1",
         "debug": "^4.3.2",
+        "enquirer": "^2.3.6",
         "execa": "^5.1.1",
+        "lilconfig": "2.0.4",
         "listr2": "^3.13.3",
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
-        "object-inspect": "1.11.0",
-        "string-argv": "0.3.1",
-        "supports-color": "9.0.2"
+        "object-inspect": "^1.11.0",
+        "string-argv": "^0.3.1",
+        "supports-color": "^9.0.2",
+        "yaml": "^1.10.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4025,6 +3996,12 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4161,18 +4138,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      }
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4197,12 +4162,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4225,9 +4184,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "progress": {
@@ -4289,6 +4248,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "2.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.61.1.tgz",
+      "integrity": "sha512-BbTXlEvB8d+XFbK/7E5doIcRtxWPRiqr0eb5vQ0+2paMM04Ye4PZY5nHOQef2ix24l/L0SpLd5hwcH15QHPdvA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "rxjs": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
@@ -4296,6 +4264,15 @@
       "dev": true,
       "requires": {
         "tslib": "~2.1.0"
+      }
+    },
+    "sade": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "semver": {
@@ -4444,6 +4421,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "totalist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+      "dev": true
+    },
     "tsconfig-paths": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
@@ -4496,6 +4479,19 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "uvu": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.2.tgz",
+      "integrity": "sha512-m2hLe7I2eROhh+tm3WE5cTo/Cv3WQA7Oc9f7JB6uWv+/zVKvfAm53bMyOoGOSZeQ7Ov2Fu9pLhFr7p07bnT20w==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3",
+        "totalist": "^2.0.0"
       }
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,22 @@
   "private": true,
   "devDependencies": {
     "@prettier/plugin-xml": "^1.1.0",
-    "eslint": "^8.2.0",
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "eslint": "^8.4.1",
     "eslint-plugin-import": "^2.25.3",
     "husky": "^7.0.4",
-    "lint-staged": "^12.0.2",
-    "prettier": "^2.4.1"
+    "lint-staged": "^12.1.2",
+    "prettier": "^2.5.1",
+    "rollup": "^2.61.1",
+    "uvu": "^0.5.2"
   },
+  "type": "module",
   "lint-staged": {
     "*.js": "eslint --cache --fix",
     "*.{xml,css,md,yml,yaml,json}": "prettier --write"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "rollup -c rollup.config.js"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,19 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+
+export default [
+  {
+    input: "node_modules/uvu/dist/index.mjs",
+    output: {
+      file: "test/uvu.js",
+    },
+    plugins: [nodeResolve()],
+  },
+
+  {
+    input: "node_modules/uvu/assert/index.mjs",
+    output: {
+      file: "test/assert.js",
+    },
+    plugins: [nodeResolve()],
+  },
+];

--- a/src/AppButton.js
+++ b/src/AppButton.js
@@ -44,7 +44,7 @@ export default function AppButton({ appInfo, content_type, entry, window }) {
       });
       return true;
     } catch (err) {
-      logError(err);
+      console.error(err);
       return false;
     }
   }
@@ -122,7 +122,7 @@ function flatpakSpawnify(appInfo) {
   }
 
   if (!Exec) {
-    logError(new Error(`No Exec for ${filename}`));
+    console.error(`No Exec for ${filename}`);
     return null;
   }
   keyFile.set_value("Desktop Entry", "Exec", `flatpak-spawn --host ${Exec}`);
@@ -166,7 +166,7 @@ export function ViewAllButton({ file, content_type, entry, window }) {
         save: false,
       });
     } catch (err) {
-      logError(err);
+      console.error(err);
       return;
     }
 

--- a/src/Entry.js
+++ b/src/Entry.js
@@ -3,8 +3,8 @@ import GLib from "gi://GLib";
 
 import { gettext as _ } from "gettext";
 
-export default function Entry({ entry, value, scheme }) {
-  entry.set_text(value);
+export default function Entry({ entry, resource, scheme }) {
+  entry.set_text(resource);
 
   if (scheme === "file") {
     entry.set_editable(false);

--- a/src/window.js
+++ b/src/window.js
@@ -1,9 +1,8 @@
 import Gtk from "gi://Gtk";
 import Gio from "gi://Gio";
-import GLib from "gi://GLib";
 import Gdk from "gi://Gdk";
 
-import { relativePath, loadStyleSheet } from "./util.js";
+import { relativePath, loadStyleSheet, readResource } from "./util.js";
 import Entry from "./Entry.js";
 import AppButton, { ViewAllButton } from "./AppButton.js";
 import { settings } from "./common.js";
@@ -15,34 +14,11 @@ export default function Window({ application, file }) {
   loadStyleSheet(relativePath("./window.css"));
   window.set_application(application);
 
-  let content_type = "application/octet-stream";
-  let value = "";
-
-  // g_file_get_uri_scheme() returns http for https so we need to use g_uri
-  // const scheme = file.get_uri_scheme();
-  const uri = GLib.uri_parse(file.get_uri(), GLib.UriFlags.NONE);
-  const scheme = uri.get_scheme();
-
-  if (scheme !== "file") {
-    content_type = `x-scheme-handler/${scheme}`;
-    value = file.get_uri();
-  } else {
-    value = file.get_path();
-    try {
-      const info = file.query_info(
-        "standard::content-type",
-        Gio.FileQueryInfoFlags.NONE,
-        null,
-      );
-      content_type = info.get_content_type();
-    } catch (err) {
-      logError(err);
-    }
-  }
+  const { content_type, resource, scheme } = readResource(file);
 
   const { entry } = Entry({
     entry: builder.get_object("entry"),
-    value,
+    resource,
     scheme,
   });
 

--- a/test/assert.js
+++ b/test/assert.js
@@ -1,0 +1,1034 @@
+var has = Object.prototype.hasOwnProperty;
+
+function find(iter, tar, key) {
+	for (key of iter.keys()) {
+		if (dequal(key, tar)) return key;
+	}
+}
+
+function dequal(foo, bar) {
+	var ctor, len, tmp;
+	if (foo === bar) return true;
+
+	if (foo && bar && (ctor=foo.constructor) === bar.constructor) {
+		if (ctor === Date) return foo.getTime() === bar.getTime();
+		if (ctor === RegExp) return foo.toString() === bar.toString();
+
+		if (ctor === Array) {
+			if ((len=foo.length) === bar.length) {
+				while (len-- && dequal(foo[len], bar[len]));
+			}
+			return len === -1;
+		}
+
+		if (ctor === Set) {
+			if (foo.size !== bar.size) {
+				return false;
+			}
+			for (len of foo) {
+				tmp = len;
+				if (tmp && typeof tmp === 'object') {
+					tmp = find(bar, tmp);
+					if (!tmp) return false;
+				}
+				if (!bar.has(tmp)) return false;
+			}
+			return true;
+		}
+
+		if (ctor === Map) {
+			if (foo.size !== bar.size) {
+				return false;
+			}
+			for (len of foo) {
+				tmp = len[0];
+				if (tmp && typeof tmp === 'object') {
+					tmp = find(bar, tmp);
+					if (!tmp) return false;
+				}
+				if (!dequal(len[1], bar.get(tmp))) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		if (ctor === ArrayBuffer) {
+			foo = new Uint8Array(foo);
+			bar = new Uint8Array(bar);
+		} else if (ctor === DataView) {
+			if ((len=foo.byteLength) === bar.byteLength) {
+				while (len-- && foo.getInt8(len) === bar.getInt8(len));
+			}
+			return len === -1;
+		}
+
+		if (ArrayBuffer.isView(foo)) {
+			if ((len=foo.byteLength) === bar.byteLength) {
+				while (len-- && foo[len] === bar[len]);
+			}
+			return len === -1;
+		}
+
+		if (!ctor || typeof foo === 'object') {
+			len = 0;
+			for (ctor in foo) {
+				if (has.call(foo, ctor) && ++len && !has.call(bar, ctor)) return false;
+				if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor])) return false;
+			}
+			return Object.keys(bar).length === len;
+		}
+	}
+
+	return foo !== foo && bar !== bar;
+}
+
+let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
+if (typeof process !== 'undefined') {
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
+	isTTY = process.stdout && process.stdout.isTTY;
+}
+
+const $ = {
+	enabled: !NODE_DISABLE_COLORS && NO_COLOR == null && TERM !== 'dumb' && (
+		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
+	),
+
+	// modifiers
+	reset: init(0, 0),
+	bold: init(1, 22),
+	dim: init(2, 22),
+	italic: init(3, 23),
+	underline: init(4, 24),
+	inverse: init(7, 27),
+	hidden: init(8, 28),
+	strikethrough: init(9, 29),
+
+	// colors
+	black: init(30, 39),
+	red: init(31, 39),
+	green: init(32, 39),
+	yellow: init(33, 39),
+	blue: init(34, 39),
+	magenta: init(35, 39),
+	cyan: init(36, 39),
+	white: init(37, 39),
+	gray: init(90, 39),
+	grey: init(90, 39),
+
+	// background colors
+	bgBlack: init(40, 49),
+	bgRed: init(41, 49),
+	bgGreen: init(42, 49),
+	bgYellow: init(43, 49),
+	bgBlue: init(44, 49),
+	bgMagenta: init(45, 49),
+	bgCyan: init(46, 49),
+	bgWhite: init(47, 49)
+};
+
+function run(arr, str) {
+	let i=0, tmp, beg='', end='';
+	for (; i < arr.length; i++) {
+		tmp = arr[i];
+		beg += tmp.open;
+		end += tmp.close;
+		if (!!~str.indexOf(tmp.close)) {
+			str = str.replace(tmp.rgx, tmp.close + tmp.open);
+		}
+	}
+	return beg + str + end;
+}
+
+function chain(has, keys) {
+	let ctx = { has, keys };
+
+	ctx.reset = $.reset.bind(ctx);
+	ctx.bold = $.bold.bind(ctx);
+	ctx.dim = $.dim.bind(ctx);
+	ctx.italic = $.italic.bind(ctx);
+	ctx.underline = $.underline.bind(ctx);
+	ctx.inverse = $.inverse.bind(ctx);
+	ctx.hidden = $.hidden.bind(ctx);
+	ctx.strikethrough = $.strikethrough.bind(ctx);
+
+	ctx.black = $.black.bind(ctx);
+	ctx.red = $.red.bind(ctx);
+	ctx.green = $.green.bind(ctx);
+	ctx.yellow = $.yellow.bind(ctx);
+	ctx.blue = $.blue.bind(ctx);
+	ctx.magenta = $.magenta.bind(ctx);
+	ctx.cyan = $.cyan.bind(ctx);
+	ctx.white = $.white.bind(ctx);
+	ctx.gray = $.gray.bind(ctx);
+	ctx.grey = $.grey.bind(ctx);
+
+	ctx.bgBlack = $.bgBlack.bind(ctx);
+	ctx.bgRed = $.bgRed.bind(ctx);
+	ctx.bgGreen = $.bgGreen.bind(ctx);
+	ctx.bgYellow = $.bgYellow.bind(ctx);
+	ctx.bgBlue = $.bgBlue.bind(ctx);
+	ctx.bgMagenta = $.bgMagenta.bind(ctx);
+	ctx.bgCyan = $.bgCyan.bind(ctx);
+	ctx.bgWhite = $.bgWhite.bind(ctx);
+
+	return ctx;
+}
+
+function init(open, close) {
+	let blk = {
+		open: `\x1b[${open}m`,
+		close: `\x1b[${close}m`,
+		rgx: new RegExp(`\\x1b\\[${close}m`, 'g')
+	};
+	return function (txt) {
+		if (this !== void 0 && this.has !== void 0) {
+			!!~this.has.indexOf(open) || (this.has.push(open),this.keys.push(blk));
+			return txt === void 0 ? this : $.enabled ? run(this.keys, txt+'') : txt+'';
+		}
+		return txt === void 0 ? chain([open], [blk]) : $.enabled ? run([blk], txt+'') : txt+'';
+	};
+}
+
+function Diff() {}
+Diff.prototype = {
+  diff: function diff(oldString, newString) {
+    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var callback = options.callback;
+
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    this.options = options;
+    var self = this;
+
+    function done(value) {
+      if (callback) {
+        setTimeout(function () {
+          callback(undefined, value);
+        }, 0);
+        return true;
+      } else {
+        return value;
+      }
+    } // Allow subclasses to massage the input prior to running
+
+
+    oldString = this.castInput(oldString);
+    newString = this.castInput(newString);
+    oldString = this.removeEmpty(this.tokenize(oldString));
+    newString = this.removeEmpty(this.tokenize(newString));
+    var newLen = newString.length,
+        oldLen = oldString.length;
+    var editLength = 1;
+    var maxEditLength = newLen + oldLen;
+    var bestPath = [{
+      newPos: -1,
+      components: []
+    }]; // Seed editLength = 0, i.e. the content starts with the same values
+
+    var oldPos = this.extractCommon(bestPath[0], newString, oldString, 0);
+
+    if (bestPath[0].newPos + 1 >= newLen && oldPos + 1 >= oldLen) {
+      // Identity per the equality and tokenizer
+      return done([{
+        value: this.join(newString),
+        count: newString.length
+      }]);
+    } // Main worker method. checks all permutations of a given edit length for acceptance.
+
+
+    function execEditLength() {
+      for (var diagonalPath = -1 * editLength; diagonalPath <= editLength; diagonalPath += 2) {
+        var basePath = void 0;
+
+        var addPath = bestPath[diagonalPath - 1],
+            removePath = bestPath[diagonalPath + 1],
+            _oldPos = (removePath ? removePath.newPos : 0) - diagonalPath;
+
+        if (addPath) {
+          // No one else is going to attempt to use this value, clear it
+          bestPath[diagonalPath - 1] = undefined;
+        }
+
+        var canAdd = addPath && addPath.newPos + 1 < newLen,
+            canRemove = removePath && 0 <= _oldPos && _oldPos < oldLen;
+
+        if (!canAdd && !canRemove) {
+          // If this path is a terminal then prune
+          bestPath[diagonalPath] = undefined;
+          continue;
+        } // Select the diagonal that we want to branch from. We select the prior
+        // path whose position in the new string is the farthest from the origin
+        // and does not pass the bounds of the diff graph
+
+
+        if (!canAdd || canRemove && addPath.newPos < removePath.newPos) {
+          basePath = clonePath(removePath);
+          self.pushComponent(basePath.components, undefined, true);
+        } else {
+          basePath = addPath; // No need to clone, we've pulled it from the list
+
+          basePath.newPos++;
+          self.pushComponent(basePath.components, true, undefined);
+        }
+
+        _oldPos = self.extractCommon(basePath, newString, oldString, diagonalPath); // If we have hit the end of both strings, then we are done
+
+        if (basePath.newPos + 1 >= newLen && _oldPos + 1 >= oldLen) {
+          return done(buildValues(self, basePath.components, newString, oldString, self.useLongestToken));
+        } else {
+          // Otherwise track this path as a potential candidate and continue.
+          bestPath[diagonalPath] = basePath;
+        }
+      }
+
+      editLength++;
+    } // Performs the length of edit iteration. Is a bit fugly as this has to support the
+    // sync and async mode which is never fun. Loops over execEditLength until a value
+    // is produced.
+
+
+    if (callback) {
+      (function exec() {
+        setTimeout(function () {
+          // This should not happen, but we want to be safe.
+
+          /* istanbul ignore next */
+          if (editLength > maxEditLength) {
+            return callback();
+          }
+
+          if (!execEditLength()) {
+            exec();
+          }
+        }, 0);
+      })();
+    } else {
+      while (editLength <= maxEditLength) {
+        var ret = execEditLength();
+
+        if (ret) {
+          return ret;
+        }
+      }
+    }
+  },
+  pushComponent: function pushComponent(components, added, removed) {
+    var last = components[components.length - 1];
+
+    if (last && last.added === added && last.removed === removed) {
+      // We need to clone here as the component clone operation is just
+      // as shallow array clone
+      components[components.length - 1] = {
+        count: last.count + 1,
+        added: added,
+        removed: removed
+      };
+    } else {
+      components.push({
+        count: 1,
+        added: added,
+        removed: removed
+      });
+    }
+  },
+  extractCommon: function extractCommon(basePath, newString, oldString, diagonalPath) {
+    var newLen = newString.length,
+        oldLen = oldString.length,
+        newPos = basePath.newPos,
+        oldPos = newPos - diagonalPath,
+        commonCount = 0;
+
+    while (newPos + 1 < newLen && oldPos + 1 < oldLen && this.equals(newString[newPos + 1], oldString[oldPos + 1])) {
+      newPos++;
+      oldPos++;
+      commonCount++;
+    }
+
+    if (commonCount) {
+      basePath.components.push({
+        count: commonCount
+      });
+    }
+
+    basePath.newPos = newPos;
+    return oldPos;
+  },
+  equals: function equals(left, right) {
+    if (this.options.comparator) {
+      return this.options.comparator(left, right);
+    } else {
+      return left === right || this.options.ignoreCase && left.toLowerCase() === right.toLowerCase();
+    }
+  },
+  removeEmpty: function removeEmpty(array) {
+    var ret = [];
+
+    for (var i = 0; i < array.length; i++) {
+      if (array[i]) {
+        ret.push(array[i]);
+      }
+    }
+
+    return ret;
+  },
+  castInput: function castInput(value) {
+    return value;
+  },
+  tokenize: function tokenize(value) {
+    return value.split('');
+  },
+  join: function join(chars) {
+    return chars.join('');
+  }
+};
+
+function buildValues(diff, components, newString, oldString, useLongestToken) {
+  var componentPos = 0,
+      componentLen = components.length,
+      newPos = 0,
+      oldPos = 0;
+
+  for (; componentPos < componentLen; componentPos++) {
+    var component = components[componentPos];
+
+    if (!component.removed) {
+      if (!component.added && useLongestToken) {
+        var value = newString.slice(newPos, newPos + component.count);
+        value = value.map(function (value, i) {
+          var oldValue = oldString[oldPos + i];
+          return oldValue.length > value.length ? oldValue : value;
+        });
+        component.value = diff.join(value);
+      } else {
+        component.value = diff.join(newString.slice(newPos, newPos + component.count));
+      }
+
+      newPos += component.count; // Common case
+
+      if (!component.added) {
+        oldPos += component.count;
+      }
+    } else {
+      component.value = diff.join(oldString.slice(oldPos, oldPos + component.count));
+      oldPos += component.count; // Reverse add and remove so removes are output first to match common convention
+      // The diffing algorithm is tied to add then remove output and this is the simplest
+      // route to get the desired output with minimal overhead.
+
+      if (componentPos && components[componentPos - 1].added) {
+        var tmp = components[componentPos - 1];
+        components[componentPos - 1] = components[componentPos];
+        components[componentPos] = tmp;
+      }
+    }
+  } // Special case handle for when one terminal is ignored (i.e. whitespace).
+  // For this case we merge the terminal into the prior string and drop the change.
+  // This is only available for string mode.
+
+
+  var lastComponent = components[componentLen - 1];
+
+  if (componentLen > 1 && typeof lastComponent.value === 'string' && (lastComponent.added || lastComponent.removed) && diff.equals('', lastComponent.value)) {
+    components[componentLen - 2].value += lastComponent.value;
+    components.pop();
+  }
+
+  return components;
+}
+
+function clonePath(path) {
+  return {
+    newPos: path.newPos,
+    components: path.components.slice(0)
+  };
+}
+
+var characterDiff = new Diff();
+function diffChars(oldStr, newStr, options) {
+  return characterDiff.diff(oldStr, newStr, options);
+}
+
+//
+// Ranges and exceptions:
+// Latin-1 Supplement, 0080–00FF
+//  - U+00D7  × Multiplication sign
+//  - U+00F7  ÷ Division sign
+// Latin Extended-A, 0100–017F
+// Latin Extended-B, 0180–024F
+// IPA Extensions, 0250–02AF
+// Spacing Modifier Letters, 02B0–02FF
+//  - U+02C7  ˇ &#711;  Caron
+//  - U+02D8  ˘ &#728;  Breve
+//  - U+02D9  ˙ &#729;  Dot Above
+//  - U+02DA  ˚ &#730;  Ring Above
+//  - U+02DB  ˛ &#731;  Ogonek
+//  - U+02DC  ˜ &#732;  Small Tilde
+//  - U+02DD  ˝ &#733;  Double Acute Accent
+// Latin Extended Additional, 1E00–1EFF
+
+var extendedWordChars = /^[A-Za-z\xC0-\u02C6\u02C8-\u02D7\u02DE-\u02FF\u1E00-\u1EFF]+$/;
+var reWhitespace = /\S/;
+var wordDiff = new Diff();
+
+wordDiff.equals = function (left, right) {
+  if (this.options.ignoreCase) {
+    left = left.toLowerCase();
+    right = right.toLowerCase();
+  }
+
+  return left === right || this.options.ignoreWhitespace && !reWhitespace.test(left) && !reWhitespace.test(right);
+};
+
+wordDiff.tokenize = function (value) {
+  // All whitespace symbols except newline group into one token, each newline - in separate token
+  var tokens = value.split(/([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/); // Join the boundary splits that we do not consider to be boundaries. This is primarily the extended Latin character set.
+
+  for (var i = 0; i < tokens.length - 1; i++) {
+    // If we have an empty string in the next field and we have only word chars before and after, merge
+    if (!tokens[i + 1] && tokens[i + 2] && extendedWordChars.test(tokens[i]) && extendedWordChars.test(tokens[i + 2])) {
+      tokens[i] += tokens[i + 2];
+      tokens.splice(i + 1, 2);
+      i--;
+    }
+  }
+
+  return tokens;
+};
+
+var lineDiff = new Diff();
+
+lineDiff.tokenize = function (value) {
+  var retLines = [],
+      linesAndNewlines = value.split(/(\n|\r\n)/); // Ignore the final empty token that occurs if the string ends with a new line
+
+  if (!linesAndNewlines[linesAndNewlines.length - 1]) {
+    linesAndNewlines.pop();
+  } // Merge the content and line separators into single tokens
+
+
+  for (var i = 0; i < linesAndNewlines.length; i++) {
+    var line = linesAndNewlines[i];
+
+    if (i % 2 && !this.options.newlineIsToken) {
+      retLines[retLines.length - 1] += line;
+    } else {
+      if (this.options.ignoreWhitespace) {
+        line = line.trim();
+      }
+
+      retLines.push(line);
+    }
+  }
+
+  return retLines;
+};
+
+function diffLines(oldStr, newStr, callback) {
+  return lineDiff.diff(oldStr, newStr, callback);
+}
+
+var sentenceDiff = new Diff();
+
+sentenceDiff.tokenize = function (value) {
+  return value.split(/(\S.+?[.!?])(?=\s+|$)/);
+};
+
+var cssDiff = new Diff();
+
+cssDiff.tokenize = function (value) {
+  return value.split(/([{}:;,]|\s+)/);
+};
+
+function _typeof(obj) {
+  "@babel/helpers - typeof";
+
+  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+    _typeof = function (obj) {
+      return typeof obj;
+    };
+  } else {
+    _typeof = function (obj) {
+      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+    };
+  }
+
+  return _typeof(obj);
+}
+
+var objectPrototypeToString = Object.prototype.toString;
+var jsonDiff = new Diff(); // Discriminate between two lines of pretty-printed, serialized JSON where one of them has a
+// dangling comma and the other doesn't. Turns out including the dangling comma yields the nicest output:
+
+jsonDiff.useLongestToken = true;
+jsonDiff.tokenize = lineDiff.tokenize;
+
+jsonDiff.castInput = function (value) {
+  var _this$options = this.options,
+      undefinedReplacement = _this$options.undefinedReplacement,
+      _this$options$stringi = _this$options.stringifyReplacer,
+      stringifyReplacer = _this$options$stringi === void 0 ? function (k, v) {
+    return typeof v === 'undefined' ? undefinedReplacement : v;
+  } : _this$options$stringi;
+  return typeof value === 'string' ? value : JSON.stringify(canonicalize(value, null, null, stringifyReplacer), stringifyReplacer, '  ');
+};
+
+jsonDiff.equals = function (left, right) {
+  return Diff.prototype.equals.call(jsonDiff, left.replace(/,([\r\n])/g, '$1'), right.replace(/,([\r\n])/g, '$1'));
+};
+// object that is already on the "stack" of items being processed. Accepts an optional replacer
+
+function canonicalize(obj, stack, replacementStack, replacer, key) {
+  stack = stack || [];
+  replacementStack = replacementStack || [];
+
+  if (replacer) {
+    obj = replacer(key, obj);
+  }
+
+  var i;
+
+  for (i = 0; i < stack.length; i += 1) {
+    if (stack[i] === obj) {
+      return replacementStack[i];
+    }
+  }
+
+  var canonicalizedObj;
+
+  if ('[object Array]' === objectPrototypeToString.call(obj)) {
+    stack.push(obj);
+    canonicalizedObj = new Array(obj.length);
+    replacementStack.push(canonicalizedObj);
+
+    for (i = 0; i < obj.length; i += 1) {
+      canonicalizedObj[i] = canonicalize(obj[i], stack, replacementStack, replacer, key);
+    }
+
+    stack.pop();
+    replacementStack.pop();
+    return canonicalizedObj;
+  }
+
+  if (obj && obj.toJSON) {
+    obj = obj.toJSON();
+  }
+
+  if (_typeof(obj) === 'object' && obj !== null) {
+    stack.push(obj);
+    canonicalizedObj = {};
+    replacementStack.push(canonicalizedObj);
+
+    var sortedKeys = [],
+        _key;
+
+    for (_key in obj) {
+      /* istanbul ignore else */
+      if (obj.hasOwnProperty(_key)) {
+        sortedKeys.push(_key);
+      }
+    }
+
+    sortedKeys.sort();
+
+    for (i = 0; i < sortedKeys.length; i += 1) {
+      _key = sortedKeys[i];
+      canonicalizedObj[_key] = canonicalize(obj[_key], stack, replacementStack, replacer, _key);
+    }
+
+    stack.pop();
+    replacementStack.pop();
+  } else {
+    canonicalizedObj = obj;
+  }
+
+  return canonicalizedObj;
+}
+
+var arrayDiff = new Diff();
+
+arrayDiff.tokenize = function (value) {
+  return value.slice();
+};
+
+arrayDiff.join = arrayDiff.removeEmpty = function (value) {
+  return value;
+};
+
+function diffArrays(oldArr, newArr, callback) {
+  return arrayDiff.diff(oldArr, newArr, callback);
+}
+
+const colors = {
+	'--': $.red,
+	'··': $.grey,
+	'++': $.green,
+};
+
+const TITLE = $.dim().italic;
+const TAB=$.dim('→'), SPACE=$.dim('·'), NL=$.dim('↵');
+const LOG = (sym, str) => colors[sym](sym + PRETTY(str)) + '\n';
+const LINE = (num, x) => $.dim('L' + String(num).padStart(x, '0') + ' ');
+const PRETTY = str => str.replace(/[ ]/g, SPACE).replace(/\t/g, TAB).replace(/(\r?\n)/g, NL);
+
+function line(obj, prev, pad) {
+	let char = obj.removed ? '--' : obj.added ? '++' : '··';
+	let arr = obj.value.replace(/\r?\n$/, '').split('\n');
+	let i=0, tmp, out='';
+
+	if (obj.added) out += colors[char]().underline(TITLE('Expected:')) + '\n';
+	else if (obj.removed) out += colors[char]().underline(TITLE('Actual:')) + '\n';
+
+	for (; i < arr.length; i++) {
+		tmp = arr[i];
+		if (tmp != null) {
+			if (prev) out += LINE(prev + i, pad);
+			out += LOG(char, tmp || '\n');
+		}
+	}
+
+	return out;
+}
+
+// TODO: want better diffing
+//~> complex items bail outright
+function arrays(input, expect) {
+	let arr = diffArrays(input, expect);
+	let i=0, j=0, k=0, tmp, val, char, isObj, str;
+	let out = LOG('··', '[');
+
+	for (; i < arr.length; i++) {
+		char = (tmp = arr[i]).removed ? '--' : tmp.added ? '++' : '··';
+
+		if (tmp.added) {
+			out += colors[char]().underline(TITLE('Expected:')) + '\n';
+		} else if (tmp.removed) {
+			out += colors[char]().underline(TITLE('Actual:')) + '\n';
+		}
+
+		for (j=0; j < tmp.value.length; j++) {
+			isObj = (tmp.value[j] && typeof tmp.value[j] === 'object');
+			val = stringify(tmp.value[j]).split(/\r?\n/g);
+			for (k=0; k < val.length;) {
+				str = '  ' + val[k++] + (isObj ? '' : ',');
+				if (isObj && k === val.length && (j + 1) < tmp.value.length) str += ',';
+				out += LOG(char, str);
+			}
+		}
+	}
+
+	return out + LOG('··', ']');
+}
+
+function lines(input, expect, linenum = 0) {
+	let i=0, tmp, output='';
+	let arr = diffLines(input, expect);
+	let pad = String(expect.split(/\r?\n/g).length - linenum).length;
+
+	for (; i < arr.length; i++) {
+		output += line(tmp = arr[i], linenum, pad);
+		if (linenum && !tmp.removed) linenum += tmp.count;
+	}
+
+	return output;
+}
+
+function chars(input, expect) {
+	let arr = diffChars(input, expect);
+	let i=0, output='', tmp;
+
+	let l1 = input.length;
+	let l2 = expect.length;
+
+	let p1 = PRETTY(input);
+	let p2 = PRETTY(expect);
+
+	tmp = arr[i];
+
+	if (l1 === l2) ; else if (tmp.removed && arr[i + 1]) {
+		let del = tmp.count - arr[i + 1].count;
+		if (del == 0) ; else if (del > 0) {
+			expect = ' '.repeat(del) + expect;
+			p2 = ' '.repeat(del) + p2;
+			l2 += del;
+		} else if (del < 0) {
+			input = ' '.repeat(-del) + input;
+			p1 = ' '.repeat(-del) + p1;
+			l1 += -del;
+		}
+	}
+
+	output += direct(p1, p2, l1, l2);
+
+	if (l1 === l2) {
+		for (tmp='  '; i < l1; i++) {
+			tmp += input[i] === expect[i] ? ' ' : '^';
+		}
+	} else {
+		for (tmp='  '; i < arr.length; i++) {
+			tmp += ((arr[i].added || arr[i].removed) ? '^' : ' ').repeat(Math.max(arr[i].count, 0));
+			if (i + 1 < arr.length && ((arr[i].added && arr[i+1].removed) || (arr[i].removed && arr[i+1].added))) {
+				arr[i + 1].count -= arr[i].count;
+			}
+		}
+	}
+
+	return output + $.red(tmp);
+}
+
+function direct(input, expect, lenA = String(input).length, lenB = String(expect).length) {
+	let gutter = 4;
+	let lenC = Math.max(lenA, lenB);
+	let typeA=typeof input, typeB=typeof expect;
+
+	if (typeA !== typeB) {
+		gutter = 2;
+
+		let delA = gutter + lenC - lenA;
+		let delB = gutter + lenC - lenB;
+
+		input += ' '.repeat(delA) + $.dim(`[${typeA}]`);
+		expect += ' '.repeat(delB) + $.dim(`[${typeB}]`);
+
+		lenA += delA + typeA.length + 2;
+		lenB += delB + typeB.length + 2;
+		lenC = Math.max(lenA, lenB);
+	}
+
+	let output = colors['++']('++' + expect + ' '.repeat(gutter + lenC - lenB) + TITLE('(Expected)')) + '\n';
+	return output + colors['--']('--' + input + ' '.repeat(gutter + lenC - lenA) + TITLE('(Actual)')) + '\n';
+}
+
+function sort(input, expect) {
+	var k, i=0, tmp, isArr = Array.isArray(input);
+	var keys=[], out=isArr ? Array(input.length) : {};
+
+	if (isArr) {
+		for (i=0; i < out.length; i++) {
+			tmp = input[i];
+			if (!tmp || typeof tmp !== 'object') out[i] = tmp;
+			else out[i] = sort(tmp, expect[i]); // might not be right
+		}
+	} else {
+		for (k in expect)
+			keys.push(k);
+
+		for (; i < keys.length; i++) {
+			if (Object.prototype.hasOwnProperty.call(input, k = keys[i])) {
+				if (!(tmp = input[k]) || typeof tmp !== 'object') out[k] = tmp;
+				else out[k] = sort(tmp, expect[k]);
+			}
+		}
+
+		for (k in input) {
+			if (!out.hasOwnProperty(k)) {
+				out[k] = input[k]; // expect didnt have
+			}
+		}
+	}
+
+	return out;
+}
+
+function circular() {
+	var cache = new Set;
+	return function print(key, val) {
+		if (val === void 0) return '[__VOID__]';
+		if (typeof val === 'number' && val !== val) return '[__NAN__]';
+		if (!val || typeof val !== 'object') return val;
+		if (cache.has(val)) return '[Circular]';
+		cache.add(val); return val;
+	}
+}
+
+function stringify(input) {
+	return JSON.stringify(input, circular(), 2).replace(/"\[__NAN__\]"/g, 'NaN').replace(/"\[__VOID__\]"/g, 'undefined');
+}
+
+function compare(input, expect) {
+	if (Array.isArray(expect)) return arrays(input, expect);
+	if (expect instanceof RegExp) return chars(''+input, ''+expect);
+
+	let isA = input && typeof input == 'object';
+	let isB = expect && typeof expect == 'object';
+
+	if (isA && isB) input = sort(input, expect);
+	if (isB) expect = stringify(expect);
+	if (isA) input = stringify(input);
+
+	if (expect && typeof expect == 'object') {
+		input = stringify(sort(input, expect));
+		expect = stringify(expect);
+	}
+
+	isA = typeof input == 'string';
+	isB = typeof expect == 'string';
+
+	if (isA && /\r?\n/.test(input)) return lines(input, ''+expect);
+	if (isB && /\r?\n/.test(expect)) return lines(''+input, expect);
+	if (isA && isB) return chars(input, expect);
+
+	return direct(input, expect);
+}
+
+function dedent(str) {
+	str = str.replace(/\r?\n/g, '\n');
+  let arr = str.match(/^[ \t]*(?=\S)/gm);
+  let i = 0, min = 1/0, len = (arr||[]).length;
+  for (; i < len; i++) min = Math.min(min, arr[i].length);
+  return len && min ? str.replace(new RegExp(`^[ \\t]{${min}}`, 'gm'), '') : str;
+}
+
+class Assertion extends Error {
+	constructor(opts={}) {
+		super(opts.message);
+		this.name = 'Assertion';
+		this.code = 'ERR_ASSERTION';
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, this.constructor);
+		}
+		this.details = opts.details || false;
+		this.generated = !!opts.generated;
+		this.operator = opts.operator;
+		this.expects = opts.expects;
+		this.actual = opts.actual;
+	}
+}
+
+function assert(bool, actual, expects, operator, detailer, backup, msg) {
+	if (bool) return;
+	let message = msg || backup;
+	if (msg instanceof Error) throw msg;
+	let details = detailer && detailer(actual, expects);
+	throw new Assertion({ actual, expects, operator, message, details, generated: !msg });
+}
+
+function ok(val, msg) {
+	assert(!!val, false, true, 'ok', false, 'Expected value to be truthy', msg);
+}
+
+function is(val, exp, msg) {
+	assert(val === exp, val, exp, 'is', compare, 'Expected values to be strictly equal:', msg);
+}
+
+function equal(val, exp, msg) {
+	assert(dequal(val, exp), val, exp, 'equal', compare, 'Expected values to be deeply equal:', msg);
+}
+
+function unreachable(msg) {
+	assert(false, true, false, 'unreachable', false, 'Expected not to be reached!', msg);
+}
+
+function type(val, exp, msg) {
+	let tmp = typeof val;
+	assert(tmp === exp, tmp, exp, 'type', false, `Expected "${tmp}" to be "${exp}"`, msg);
+}
+
+function instance(val, exp, msg) {
+	let name = '`' + (exp.name || exp.constructor.name) + '`';
+	assert(val instanceof exp, val, exp, 'instance', false, `Expected value to be an instance of ${name}`, msg);
+}
+
+function match(val, exp, msg) {
+	if (typeof exp === 'string') {
+		assert(val.includes(exp), val, exp, 'match', false, `Expected value to include "${exp}" substring`, msg);
+	} else {
+		assert(exp.test(val), val, exp, 'match', false, `Expected value to match \`${String(exp)}\` pattern`, msg);
+	}
+}
+
+function snapshot(val, exp, msg) {
+	val=dedent(val); exp=dedent(exp);
+	assert(val === exp, val, exp, 'snapshot', lines, 'Expected value to match snapshot:', msg);
+}
+
+const lineNums = (x, y) => lines(x, y, 1);
+function fixture(val, exp, msg) {
+	val=dedent(val); exp=dedent(exp);
+	assert(val === exp, val, exp, 'fixture', lineNums, 'Expected value to match fixture:', msg);
+}
+
+function throws(blk, exp, msg) {
+	if (!msg && typeof exp === 'string') {
+		msg = exp; exp = null;
+	}
+
+	try {
+		blk();
+		assert(false, false, true, 'throws', false, 'Expected function to throw', msg);
+	} catch (err) {
+		if (err instanceof Assertion) throw err;
+
+		if (typeof exp === 'function') {
+			assert(exp(err), false, true, 'throws', false, 'Expected function to throw matching exception', msg);
+		} else if (exp instanceof RegExp) {
+			assert(exp.test(err.message), false, true, 'throws', false, `Expected function to throw exception matching \`${String(exp)}\` pattern`, msg);
+		}
+	}
+}
+
+// ---
+
+function not(val, msg) {
+	assert(!val, true, false, 'not', false, 'Expected value to be falsey', msg);
+}
+
+not.ok = not;
+
+is.not = function (val, exp, msg) {
+	assert(val !== exp, val, exp, 'is.not', false, 'Expected values not to be strictly equal', msg);
+};
+
+not.equal = function (val, exp, msg) {
+	assert(!dequal(val, exp), val, exp, 'not.equal', false, 'Expected values not to be deeply equal', msg);
+};
+
+not.type = function (val, exp, msg) {
+	let tmp = typeof val;
+	assert(tmp !== exp, tmp, exp, 'not.type', false, `Expected "${tmp}" not to be "${exp}"`, msg);
+};
+
+not.instance = function (val, exp, msg) {
+	let name = '`' + (exp.name || exp.constructor.name) + '`';
+	assert(!(val instanceof exp), val, exp, 'not.instance', false, `Expected value not to be an instance of ${name}`, msg);
+};
+
+not.snapshot = function (val, exp, msg) {
+	val=dedent(val); exp=dedent(exp);
+	assert(val !== exp, val, exp, 'not.snapshot', false, 'Expected value not to match snapshot', msg);
+};
+
+not.fixture = function (val, exp, msg) {
+	val=dedent(val); exp=dedent(exp);
+	assert(val !== exp, val, exp, 'not.fixture', false, 'Expected value not to match fixture', msg);
+};
+
+not.match = function (val, exp, msg) {
+	if (typeof exp === 'string') {
+		assert(!val.includes(exp), val, exp, 'not.match', false, `Expected value not to include "${exp}" substring`, msg);
+	} else {
+		assert(!exp.test(val), val, exp, 'not.match', false, `Expected value not to match \`${String(exp)}\` pattern`, msg);
+	}
+};
+
+not.throws = function (blk, exp, msg) {
+	if (!msg && typeof exp === 'string') {
+		msg = exp; exp = null;
+	}
+
+	try {
+		blk();
+	} catch (err) {
+		if (typeof exp === 'function') {
+			assert(!exp(err), true, false, 'not.throws', false, 'Expected function not to throw matching exception', msg);
+		} else if (exp instanceof RegExp) {
+			assert(!exp.test(err.message), true, false, 'not.throws', false, `Expected function not to throw exception matching \`${String(exp)}\` pattern`, msg);
+		} else if (!exp) {
+			assert(false, true, false, 'not.throws', false, 'Expected function not to throw', msg);
+		}
+	}
+};
+
+export { Assertion, equal, fixture, instance, is, match, not, ok, snapshot, throws, type, unreachable };

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,37 @@
+import "gi://Gtk?version=4.0";
+import GLib from "gi://GLib";
+import { stdout, stderr } from "../src/util.js";
+
+globalThis.setTimeout = function setTimeout(func, delay, ...args) {
+  if (typeof delay !== "number" || delay < 0) delay = 0;
+
+  return GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
+    func(...args);
+    return false;
+  });
+};
+
+globalThis.clearTimeout = function clearTimeout(id) {
+  if (!id) return;
+  return GLib.source_remove(id);
+};
+
+globalThis.setInterval = function setInterval(func, delay, ...args) {
+  if (typeof delay !== "number" || delay < 0) delay = 0;
+
+  return GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
+    func(...args);
+    return true;
+  });
+};
+
+globalThis.clearInterval = function clearInterval(id) {
+  return GLib.source_remove(id);
+};
+
+const decoder = new TextDecoder();
+GLib.log_set_writer_func((log_level, fields) => {
+  const output = log_level === GLib.LogLevelFlags.LEVEL_ERROR ? stderr : stdout;
+  output.put_string(decoder.decode(fields.MESSAGE), null);
+  return GLib.LogWriterOutput.HANDLED;
+});

--- a/test/uvu.js
+++ b/test/uvu.js
@@ -1,0 +1,942 @@
+let FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM, isTTY=true;
+if (typeof process !== 'undefined') {
+	({ FORCE_COLOR, NODE_DISABLE_COLORS, NO_COLOR, TERM } = process.env);
+	isTTY = process.stdout && process.stdout.isTTY;
+}
+
+const $ = {
+	enabled: !NODE_DISABLE_COLORS && NO_COLOR == null && TERM !== 'dumb' && (
+		FORCE_COLOR != null && FORCE_COLOR !== '0' || isTTY
+	),
+
+	// modifiers
+	reset: init(0, 0),
+	bold: init(1, 22),
+	dim: init(2, 22),
+	italic: init(3, 23),
+	underline: init(4, 24),
+	inverse: init(7, 27),
+	hidden: init(8, 28),
+	strikethrough: init(9, 29),
+
+	// colors
+	black: init(30, 39),
+	red: init(31, 39),
+	green: init(32, 39),
+	yellow: init(33, 39),
+	blue: init(34, 39),
+	magenta: init(35, 39),
+	cyan: init(36, 39),
+	white: init(37, 39),
+	gray: init(90, 39),
+	grey: init(90, 39),
+
+	// background colors
+	bgBlack: init(40, 49),
+	bgRed: init(41, 49),
+	bgGreen: init(42, 49),
+	bgYellow: init(43, 49),
+	bgBlue: init(44, 49),
+	bgMagenta: init(45, 49),
+	bgCyan: init(46, 49),
+	bgWhite: init(47, 49)
+};
+
+function run(arr, str) {
+	let i=0, tmp, beg='', end='';
+	for (; i < arr.length; i++) {
+		tmp = arr[i];
+		beg += tmp.open;
+		end += tmp.close;
+		if (!!~str.indexOf(tmp.close)) {
+			str = str.replace(tmp.rgx, tmp.close + tmp.open);
+		}
+	}
+	return beg + str + end;
+}
+
+function chain(has, keys) {
+	let ctx = { has, keys };
+
+	ctx.reset = $.reset.bind(ctx);
+	ctx.bold = $.bold.bind(ctx);
+	ctx.dim = $.dim.bind(ctx);
+	ctx.italic = $.italic.bind(ctx);
+	ctx.underline = $.underline.bind(ctx);
+	ctx.inverse = $.inverse.bind(ctx);
+	ctx.hidden = $.hidden.bind(ctx);
+	ctx.strikethrough = $.strikethrough.bind(ctx);
+
+	ctx.black = $.black.bind(ctx);
+	ctx.red = $.red.bind(ctx);
+	ctx.green = $.green.bind(ctx);
+	ctx.yellow = $.yellow.bind(ctx);
+	ctx.blue = $.blue.bind(ctx);
+	ctx.magenta = $.magenta.bind(ctx);
+	ctx.cyan = $.cyan.bind(ctx);
+	ctx.white = $.white.bind(ctx);
+	ctx.gray = $.gray.bind(ctx);
+	ctx.grey = $.grey.bind(ctx);
+
+	ctx.bgBlack = $.bgBlack.bind(ctx);
+	ctx.bgRed = $.bgRed.bind(ctx);
+	ctx.bgGreen = $.bgGreen.bind(ctx);
+	ctx.bgYellow = $.bgYellow.bind(ctx);
+	ctx.bgBlue = $.bgBlue.bind(ctx);
+	ctx.bgMagenta = $.bgMagenta.bind(ctx);
+	ctx.bgCyan = $.bgCyan.bind(ctx);
+	ctx.bgWhite = $.bgWhite.bind(ctx);
+
+	return ctx;
+}
+
+function init(open, close) {
+	let blk = {
+		open: `\x1b[${open}m`,
+		close: `\x1b[${close}m`,
+		rgx: new RegExp(`\\x1b\\[${close}m`, 'g')
+	};
+	return function (txt) {
+		if (this !== void 0 && this.has !== void 0) {
+			!!~this.has.indexOf(open) || (this.has.push(open),this.keys.push(blk));
+			return txt === void 0 ? this : $.enabled ? run(this.keys, txt+'') : txt+'';
+		}
+		return txt === void 0 ? chain([open], [blk]) : $.enabled ? run([blk], txt+'') : txt+'';
+	};
+}
+
+function Diff() {}
+Diff.prototype = {
+  diff: function diff(oldString, newString) {
+    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var callback = options.callback;
+
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+
+    this.options = options;
+    var self = this;
+
+    function done(value) {
+      if (callback) {
+        setTimeout(function () {
+          callback(undefined, value);
+        }, 0);
+        return true;
+      } else {
+        return value;
+      }
+    } // Allow subclasses to massage the input prior to running
+
+
+    oldString = this.castInput(oldString);
+    newString = this.castInput(newString);
+    oldString = this.removeEmpty(this.tokenize(oldString));
+    newString = this.removeEmpty(this.tokenize(newString));
+    var newLen = newString.length,
+        oldLen = oldString.length;
+    var editLength = 1;
+    var maxEditLength = newLen + oldLen;
+    var bestPath = [{
+      newPos: -1,
+      components: []
+    }]; // Seed editLength = 0, i.e. the content starts with the same values
+
+    var oldPos = this.extractCommon(bestPath[0], newString, oldString, 0);
+
+    if (bestPath[0].newPos + 1 >= newLen && oldPos + 1 >= oldLen) {
+      // Identity per the equality and tokenizer
+      return done([{
+        value: this.join(newString),
+        count: newString.length
+      }]);
+    } // Main worker method. checks all permutations of a given edit length for acceptance.
+
+
+    function execEditLength() {
+      for (var diagonalPath = -1 * editLength; diagonalPath <= editLength; diagonalPath += 2) {
+        var basePath = void 0;
+
+        var addPath = bestPath[diagonalPath - 1],
+            removePath = bestPath[diagonalPath + 1],
+            _oldPos = (removePath ? removePath.newPos : 0) - diagonalPath;
+
+        if (addPath) {
+          // No one else is going to attempt to use this value, clear it
+          bestPath[diagonalPath - 1] = undefined;
+        }
+
+        var canAdd = addPath && addPath.newPos + 1 < newLen,
+            canRemove = removePath && 0 <= _oldPos && _oldPos < oldLen;
+
+        if (!canAdd && !canRemove) {
+          // If this path is a terminal then prune
+          bestPath[diagonalPath] = undefined;
+          continue;
+        } // Select the diagonal that we want to branch from. We select the prior
+        // path whose position in the new string is the farthest from the origin
+        // and does not pass the bounds of the diff graph
+
+
+        if (!canAdd || canRemove && addPath.newPos < removePath.newPos) {
+          basePath = clonePath(removePath);
+          self.pushComponent(basePath.components, undefined, true);
+        } else {
+          basePath = addPath; // No need to clone, we've pulled it from the list
+
+          basePath.newPos++;
+          self.pushComponent(basePath.components, true, undefined);
+        }
+
+        _oldPos = self.extractCommon(basePath, newString, oldString, diagonalPath); // If we have hit the end of both strings, then we are done
+
+        if (basePath.newPos + 1 >= newLen && _oldPos + 1 >= oldLen) {
+          return done(buildValues(self, basePath.components, newString, oldString, self.useLongestToken));
+        } else {
+          // Otherwise track this path as a potential candidate and continue.
+          bestPath[diagonalPath] = basePath;
+        }
+      }
+
+      editLength++;
+    } // Performs the length of edit iteration. Is a bit fugly as this has to support the
+    // sync and async mode which is never fun. Loops over execEditLength until a value
+    // is produced.
+
+
+    if (callback) {
+      (function exec() {
+        setTimeout(function () {
+          // This should not happen, but we want to be safe.
+
+          /* istanbul ignore next */
+          if (editLength > maxEditLength) {
+            return callback();
+          }
+
+          if (!execEditLength()) {
+            exec();
+          }
+        }, 0);
+      })();
+    } else {
+      while (editLength <= maxEditLength) {
+        var ret = execEditLength();
+
+        if (ret) {
+          return ret;
+        }
+      }
+    }
+  },
+  pushComponent: function pushComponent(components, added, removed) {
+    var last = components[components.length - 1];
+
+    if (last && last.added === added && last.removed === removed) {
+      // We need to clone here as the component clone operation is just
+      // as shallow array clone
+      components[components.length - 1] = {
+        count: last.count + 1,
+        added: added,
+        removed: removed
+      };
+    } else {
+      components.push({
+        count: 1,
+        added: added,
+        removed: removed
+      });
+    }
+  },
+  extractCommon: function extractCommon(basePath, newString, oldString, diagonalPath) {
+    var newLen = newString.length,
+        oldLen = oldString.length,
+        newPos = basePath.newPos,
+        oldPos = newPos - diagonalPath,
+        commonCount = 0;
+
+    while (newPos + 1 < newLen && oldPos + 1 < oldLen && this.equals(newString[newPos + 1], oldString[oldPos + 1])) {
+      newPos++;
+      oldPos++;
+      commonCount++;
+    }
+
+    if (commonCount) {
+      basePath.components.push({
+        count: commonCount
+      });
+    }
+
+    basePath.newPos = newPos;
+    return oldPos;
+  },
+  equals: function equals(left, right) {
+    if (this.options.comparator) {
+      return this.options.comparator(left, right);
+    } else {
+      return left === right || this.options.ignoreCase && left.toLowerCase() === right.toLowerCase();
+    }
+  },
+  removeEmpty: function removeEmpty(array) {
+    var ret = [];
+
+    for (var i = 0; i < array.length; i++) {
+      if (array[i]) {
+        ret.push(array[i]);
+      }
+    }
+
+    return ret;
+  },
+  castInput: function castInput(value) {
+    return value;
+  },
+  tokenize: function tokenize(value) {
+    return value.split('');
+  },
+  join: function join(chars) {
+    return chars.join('');
+  }
+};
+
+function buildValues(diff, components, newString, oldString, useLongestToken) {
+  var componentPos = 0,
+      componentLen = components.length,
+      newPos = 0,
+      oldPos = 0;
+
+  for (; componentPos < componentLen; componentPos++) {
+    var component = components[componentPos];
+
+    if (!component.removed) {
+      if (!component.added && useLongestToken) {
+        var value = newString.slice(newPos, newPos + component.count);
+        value = value.map(function (value, i) {
+          var oldValue = oldString[oldPos + i];
+          return oldValue.length > value.length ? oldValue : value;
+        });
+        component.value = diff.join(value);
+      } else {
+        component.value = diff.join(newString.slice(newPos, newPos + component.count));
+      }
+
+      newPos += component.count; // Common case
+
+      if (!component.added) {
+        oldPos += component.count;
+      }
+    } else {
+      component.value = diff.join(oldString.slice(oldPos, oldPos + component.count));
+      oldPos += component.count; // Reverse add and remove so removes are output first to match common convention
+      // The diffing algorithm is tied to add then remove output and this is the simplest
+      // route to get the desired output with minimal overhead.
+
+      if (componentPos && components[componentPos - 1].added) {
+        var tmp = components[componentPos - 1];
+        components[componentPos - 1] = components[componentPos];
+        components[componentPos] = tmp;
+      }
+    }
+  } // Special case handle for when one terminal is ignored (i.e. whitespace).
+  // For this case we merge the terminal into the prior string and drop the change.
+  // This is only available for string mode.
+
+
+  var lastComponent = components[componentLen - 1];
+
+  if (componentLen > 1 && typeof lastComponent.value === 'string' && (lastComponent.added || lastComponent.removed) && diff.equals('', lastComponent.value)) {
+    components[componentLen - 2].value += lastComponent.value;
+    components.pop();
+  }
+
+  return components;
+}
+
+function clonePath(path) {
+  return {
+    newPos: path.newPos,
+    components: path.components.slice(0)
+  };
+}
+
+var characterDiff = new Diff();
+function diffChars(oldStr, newStr, options) {
+  return characterDiff.diff(oldStr, newStr, options);
+}
+
+//
+// Ranges and exceptions:
+// Latin-1 Supplement, 0080–00FF
+//  - U+00D7  × Multiplication sign
+//  - U+00F7  ÷ Division sign
+// Latin Extended-A, 0100–017F
+// Latin Extended-B, 0180–024F
+// IPA Extensions, 0250–02AF
+// Spacing Modifier Letters, 02B0–02FF
+//  - U+02C7  ˇ &#711;  Caron
+//  - U+02D8  ˘ &#728;  Breve
+//  - U+02D9  ˙ &#729;  Dot Above
+//  - U+02DA  ˚ &#730;  Ring Above
+//  - U+02DB  ˛ &#731;  Ogonek
+//  - U+02DC  ˜ &#732;  Small Tilde
+//  - U+02DD  ˝ &#733;  Double Acute Accent
+// Latin Extended Additional, 1E00–1EFF
+
+var extendedWordChars = /^[A-Za-z\xC0-\u02C6\u02C8-\u02D7\u02DE-\u02FF\u1E00-\u1EFF]+$/;
+var reWhitespace = /\S/;
+var wordDiff = new Diff();
+
+wordDiff.equals = function (left, right) {
+  if (this.options.ignoreCase) {
+    left = left.toLowerCase();
+    right = right.toLowerCase();
+  }
+
+  return left === right || this.options.ignoreWhitespace && !reWhitespace.test(left) && !reWhitespace.test(right);
+};
+
+wordDiff.tokenize = function (value) {
+  // All whitespace symbols except newline group into one token, each newline - in separate token
+  var tokens = value.split(/([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/); // Join the boundary splits that we do not consider to be boundaries. This is primarily the extended Latin character set.
+
+  for (var i = 0; i < tokens.length - 1; i++) {
+    // If we have an empty string in the next field and we have only word chars before and after, merge
+    if (!tokens[i + 1] && tokens[i + 2] && extendedWordChars.test(tokens[i]) && extendedWordChars.test(tokens[i + 2])) {
+      tokens[i] += tokens[i + 2];
+      tokens.splice(i + 1, 2);
+      i--;
+    }
+  }
+
+  return tokens;
+};
+
+var lineDiff = new Diff();
+
+lineDiff.tokenize = function (value) {
+  var retLines = [],
+      linesAndNewlines = value.split(/(\n|\r\n)/); // Ignore the final empty token that occurs if the string ends with a new line
+
+  if (!linesAndNewlines[linesAndNewlines.length - 1]) {
+    linesAndNewlines.pop();
+  } // Merge the content and line separators into single tokens
+
+
+  for (var i = 0; i < linesAndNewlines.length; i++) {
+    var line = linesAndNewlines[i];
+
+    if (i % 2 && !this.options.newlineIsToken) {
+      retLines[retLines.length - 1] += line;
+    } else {
+      if (this.options.ignoreWhitespace) {
+        line = line.trim();
+      }
+
+      retLines.push(line);
+    }
+  }
+
+  return retLines;
+};
+
+function diffLines(oldStr, newStr, callback) {
+  return lineDiff.diff(oldStr, newStr, callback);
+}
+
+var sentenceDiff = new Diff();
+
+sentenceDiff.tokenize = function (value) {
+  return value.split(/(\S.+?[.!?])(?=\s+|$)/);
+};
+
+var cssDiff = new Diff();
+
+cssDiff.tokenize = function (value) {
+  return value.split(/([{}:;,]|\s+)/);
+};
+
+function _typeof(obj) {
+  "@babel/helpers - typeof";
+
+  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+    _typeof = function (obj) {
+      return typeof obj;
+    };
+  } else {
+    _typeof = function (obj) {
+      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+    };
+  }
+
+  return _typeof(obj);
+}
+
+var objectPrototypeToString = Object.prototype.toString;
+var jsonDiff = new Diff(); // Discriminate between two lines of pretty-printed, serialized JSON where one of them has a
+// dangling comma and the other doesn't. Turns out including the dangling comma yields the nicest output:
+
+jsonDiff.useLongestToken = true;
+jsonDiff.tokenize = lineDiff.tokenize;
+
+jsonDiff.castInput = function (value) {
+  var _this$options = this.options,
+      undefinedReplacement = _this$options.undefinedReplacement,
+      _this$options$stringi = _this$options.stringifyReplacer,
+      stringifyReplacer = _this$options$stringi === void 0 ? function (k, v) {
+    return typeof v === 'undefined' ? undefinedReplacement : v;
+  } : _this$options$stringi;
+  return typeof value === 'string' ? value : JSON.stringify(canonicalize(value, null, null, stringifyReplacer), stringifyReplacer, '  ');
+};
+
+jsonDiff.equals = function (left, right) {
+  return Diff.prototype.equals.call(jsonDiff, left.replace(/,([\r\n])/g, '$1'), right.replace(/,([\r\n])/g, '$1'));
+};
+// object that is already on the "stack" of items being processed. Accepts an optional replacer
+
+function canonicalize(obj, stack, replacementStack, replacer, key) {
+  stack = stack || [];
+  replacementStack = replacementStack || [];
+
+  if (replacer) {
+    obj = replacer(key, obj);
+  }
+
+  var i;
+
+  for (i = 0; i < stack.length; i += 1) {
+    if (stack[i] === obj) {
+      return replacementStack[i];
+    }
+  }
+
+  var canonicalizedObj;
+
+  if ('[object Array]' === objectPrototypeToString.call(obj)) {
+    stack.push(obj);
+    canonicalizedObj = new Array(obj.length);
+    replacementStack.push(canonicalizedObj);
+
+    for (i = 0; i < obj.length; i += 1) {
+      canonicalizedObj[i] = canonicalize(obj[i], stack, replacementStack, replacer, key);
+    }
+
+    stack.pop();
+    replacementStack.pop();
+    return canonicalizedObj;
+  }
+
+  if (obj && obj.toJSON) {
+    obj = obj.toJSON();
+  }
+
+  if (_typeof(obj) === 'object' && obj !== null) {
+    stack.push(obj);
+    canonicalizedObj = {};
+    replacementStack.push(canonicalizedObj);
+
+    var sortedKeys = [],
+        _key;
+
+    for (_key in obj) {
+      /* istanbul ignore else */
+      if (obj.hasOwnProperty(_key)) {
+        sortedKeys.push(_key);
+      }
+    }
+
+    sortedKeys.sort();
+
+    for (i = 0; i < sortedKeys.length; i += 1) {
+      _key = sortedKeys[i];
+      canonicalizedObj[_key] = canonicalize(obj[_key], stack, replacementStack, replacer, _key);
+    }
+
+    stack.pop();
+    replacementStack.pop();
+  } else {
+    canonicalizedObj = obj;
+  }
+
+  return canonicalizedObj;
+}
+
+var arrayDiff = new Diff();
+
+arrayDiff.tokenize = function (value) {
+  return value.slice();
+};
+
+arrayDiff.join = arrayDiff.removeEmpty = function (value) {
+  return value;
+};
+
+function diffArrays(oldArr, newArr, callback) {
+  return arrayDiff.diff(oldArr, newArr, callback);
+}
+
+const colors = {
+	'--': $.red,
+	'··': $.grey,
+	'++': $.green,
+};
+
+const TITLE = $.dim().italic;
+const TAB=$.dim('→'), SPACE=$.dim('·'), NL=$.dim('↵');
+const LOG = (sym, str) => colors[sym](sym + PRETTY(str)) + '\n';
+const LINE = (num, x) => $.dim('L' + String(num).padStart(x, '0') + ' ');
+const PRETTY = str => str.replace(/[ ]/g, SPACE).replace(/\t/g, TAB).replace(/(\r?\n)/g, NL);
+
+function line(obj, prev, pad) {
+	let char = obj.removed ? '--' : obj.added ? '++' : '··';
+	let arr = obj.value.replace(/\r?\n$/, '').split('\n');
+	let i=0, tmp, out='';
+
+	if (obj.added) out += colors[char]().underline(TITLE('Expected:')) + '\n';
+	else if (obj.removed) out += colors[char]().underline(TITLE('Actual:')) + '\n';
+
+	for (; i < arr.length; i++) {
+		tmp = arr[i];
+		if (tmp != null) {
+			if (prev) out += LINE(prev + i, pad);
+			out += LOG(char, tmp || '\n');
+		}
+	}
+
+	return out;
+}
+
+// TODO: want better diffing
+//~> complex items bail outright
+function arrays(input, expect) {
+	let arr = diffArrays(input, expect);
+	let i=0, j=0, k=0, tmp, val, char, isObj, str;
+	let out = LOG('··', '[');
+
+	for (; i < arr.length; i++) {
+		char = (tmp = arr[i]).removed ? '--' : tmp.added ? '++' : '··';
+
+		if (tmp.added) {
+			out += colors[char]().underline(TITLE('Expected:')) + '\n';
+		} else if (tmp.removed) {
+			out += colors[char]().underline(TITLE('Actual:')) + '\n';
+		}
+
+		for (j=0; j < tmp.value.length; j++) {
+			isObj = (tmp.value[j] && typeof tmp.value[j] === 'object');
+			val = stringify(tmp.value[j]).split(/\r?\n/g);
+			for (k=0; k < val.length;) {
+				str = '  ' + val[k++] + (isObj ? '' : ',');
+				if (isObj && k === val.length && (j + 1) < tmp.value.length) str += ',';
+				out += LOG(char, str);
+			}
+		}
+	}
+
+	return out + LOG('··', ']');
+}
+
+function lines(input, expect, linenum = 0) {
+	let i=0, tmp, output='';
+	let arr = diffLines(input, expect);
+	let pad = String(expect.split(/\r?\n/g).length - linenum).length;
+
+	for (; i < arr.length; i++) {
+		output += line(tmp = arr[i], linenum, pad);
+		if (linenum && !tmp.removed) linenum += tmp.count;
+	}
+
+	return output;
+}
+
+function chars(input, expect) {
+	let arr = diffChars(input, expect);
+	let i=0, output='', tmp;
+
+	let l1 = input.length;
+	let l2 = expect.length;
+
+	let p1 = PRETTY(input);
+	let p2 = PRETTY(expect);
+
+	tmp = arr[i];
+
+	if (l1 === l2) ; else if (tmp.removed && arr[i + 1]) {
+		let del = tmp.count - arr[i + 1].count;
+		if (del == 0) ; else if (del > 0) {
+			expect = ' '.repeat(del) + expect;
+			p2 = ' '.repeat(del) + p2;
+			l2 += del;
+		} else if (del < 0) {
+			input = ' '.repeat(-del) + input;
+			p1 = ' '.repeat(-del) + p1;
+			l1 += -del;
+		}
+	}
+
+	output += direct(p1, p2, l1, l2);
+
+	if (l1 === l2) {
+		for (tmp='  '; i < l1; i++) {
+			tmp += input[i] === expect[i] ? ' ' : '^';
+		}
+	} else {
+		for (tmp='  '; i < arr.length; i++) {
+			tmp += ((arr[i].added || arr[i].removed) ? '^' : ' ').repeat(Math.max(arr[i].count, 0));
+			if (i + 1 < arr.length && ((arr[i].added && arr[i+1].removed) || (arr[i].removed && arr[i+1].added))) {
+				arr[i + 1].count -= arr[i].count;
+			}
+		}
+	}
+
+	return output + $.red(tmp);
+}
+
+function direct(input, expect, lenA = String(input).length, lenB = String(expect).length) {
+	let gutter = 4;
+	let lenC = Math.max(lenA, lenB);
+	let typeA=typeof input, typeB=typeof expect;
+
+	if (typeA !== typeB) {
+		gutter = 2;
+
+		let delA = gutter + lenC - lenA;
+		let delB = gutter + lenC - lenB;
+
+		input += ' '.repeat(delA) + $.dim(`[${typeA}]`);
+		expect += ' '.repeat(delB) + $.dim(`[${typeB}]`);
+
+		lenA += delA + typeA.length + 2;
+		lenB += delB + typeB.length + 2;
+		lenC = Math.max(lenA, lenB);
+	}
+
+	let output = colors['++']('++' + expect + ' '.repeat(gutter + lenC - lenB) + TITLE('(Expected)')) + '\n';
+	return output + colors['--']('--' + input + ' '.repeat(gutter + lenC - lenA) + TITLE('(Actual)')) + '\n';
+}
+
+function sort(input, expect) {
+	var k, i=0, tmp, isArr = Array.isArray(input);
+	var keys=[], out=isArr ? Array(input.length) : {};
+
+	if (isArr) {
+		for (i=0; i < out.length; i++) {
+			tmp = input[i];
+			if (!tmp || typeof tmp !== 'object') out[i] = tmp;
+			else out[i] = sort(tmp, expect[i]); // might not be right
+		}
+	} else {
+		for (k in expect)
+			keys.push(k);
+
+		for (; i < keys.length; i++) {
+			if (Object.prototype.hasOwnProperty.call(input, k = keys[i])) {
+				if (!(tmp = input[k]) || typeof tmp !== 'object') out[k] = tmp;
+				else out[k] = sort(tmp, expect[k]);
+			}
+		}
+
+		for (k in input) {
+			if (!out.hasOwnProperty(k)) {
+				out[k] = input[k]; // expect didnt have
+			}
+		}
+	}
+
+	return out;
+}
+
+function circular() {
+	var cache = new Set;
+	return function print(key, val) {
+		if (val === void 0) return '[__VOID__]';
+		if (typeof val === 'number' && val !== val) return '[__NAN__]';
+		if (!val || typeof val !== 'object') return val;
+		if (cache.has(val)) return '[Circular]';
+		cache.add(val); return val;
+	}
+}
+
+function stringify(input) {
+	return JSON.stringify(input, circular(), 2).replace(/"\[__NAN__\]"/g, 'NaN').replace(/"\[__VOID__\]"/g, 'undefined');
+}
+
+function compare(input, expect) {
+	if (Array.isArray(expect)) return arrays(input, expect);
+	if (expect instanceof RegExp) return chars(''+input, ''+expect);
+
+	let isA = input && typeof input == 'object';
+	let isB = expect && typeof expect == 'object';
+
+	if (isA && isB) input = sort(input, expect);
+	if (isB) expect = stringify(expect);
+	if (isA) input = stringify(input);
+
+	if (expect && typeof expect == 'object') {
+		input = stringify(sort(input, expect));
+		expect = stringify(expect);
+	}
+
+	isA = typeof input == 'string';
+	isB = typeof expect == 'string';
+
+	if (isA && /\r?\n/.test(input)) return lines(input, ''+expect);
+	if (isB && /\r?\n/.test(expect)) return lines(''+input, expect);
+	if (isA && isB) return chars(input, expect);
+
+	return direct(input, expect);
+}
+
+let isCLI = false, isNode = false;
+let hrtime = (now = Date.now()) => () => (Date.now() - now).toFixed(2) + 'ms';
+let write = console.log;
+
+const into = (ctx, key) => (name, handler) => ctx[key].push({ name, handler });
+const context = (state) => ({ tests:[], before:[], after:[], bEach:[], aEach:[], only:[], skips:0, state });
+const milli = arr => (arr[0]*1e3 + arr[1]/1e6).toFixed(2) + 'ms';
+const hook = (ctx, key) => handler => ctx[key].push(handler);
+
+if (isNode = typeof process < 'u' && typeof process.stdout < 'u') {
+	// globalThis polyfill; Node < 12
+	if (typeof globalThis !== 'object') {
+		Object.defineProperty(global, 'globalThis', {
+			get: function () { return this }
+		});
+	}
+
+	let rgx = /(\.bin[\\+\/]uvu$|uvu[\\+\/]bin\.js)/i;
+	isCLI = process.argv.some(x => rgx.test(x));
+
+	// attach node-specific utils
+	write = x => process.stdout.write(x);
+	hrtime = (now = process.hrtime()) => () => milli(process.hrtime(now));
+} else if (typeof performance < 'u') {
+	hrtime = (now = performance.now()) => () => (performance.now() - now).toFixed(2) + 'ms';
+}
+
+globalThis.UVU_QUEUE = globalThis.UVU_QUEUE || [];
+isCLI || UVU_QUEUE.push([null]);
+
+const QUOTE = $.dim('"'), GUTTER = '\n        ';
+const FAIL = $.red('✘ '), PASS = $.gray('• ');
+const IGNORE = /^\s*at.*(?:\(|\s)(?:node|(internal\/[\w/]*))/;
+const FAILURE = $.bold().bgRed(' FAIL ');
+const FILE = $.bold().underline().white;
+const SUITE = $.bgWhite().bold;
+
+function stack(stack, idx) {
+	let i=0, line, out='';
+	let arr = stack.substring(idx).replace(/\\/g, '/').split('\n');
+	for (; i < arr.length; i++) {
+		line = arr[i].trim();
+		if (line.length && !IGNORE.test(line)) {
+			out += '\n    ' + line;
+		}
+	}
+	return $.grey(out) + '\n';
+}
+
+function format(name, err, suite = '') {
+	let { details, operator='' } = err;
+	let idx = err.stack && err.stack.indexOf('\n');
+	if (err.name.startsWith('AssertionError') && !operator.includes('not')) details = compare(err.actual, err.expected); // TODO?
+	let str = '  ' + FAILURE + (suite ? $.red(SUITE(` ${suite} `)) : '') + ' ' + QUOTE + $.red().bold(name) + QUOTE;
+	str += '\n    ' + err.message + (operator ? $.italic().dim(`  (${operator})`) : '') + '\n';
+	if (details) str += GUTTER + details.split('\n').join(GUTTER);
+	if (!!~idx) str += stack(err.stack, idx);
+	return str + '\n';
+}
+
+async function runner(ctx, name) {
+	let { only, tests, before, after, bEach, aEach, state } = ctx;
+	let hook, test, arr = only.length ? only : tests;
+	let num=0, errors='', total=arr.length;
+
+	try {
+		if (name) write(SUITE($.black(` ${name} `)) + ' ');
+		for (hook of before) await hook(state);
+
+		for (test of arr) {
+			state.__test__ = test.name;
+			try {
+				for (hook of bEach) await hook(state);
+				await test.handler(state);
+				for (hook of aEach) await hook(state);
+				write(PASS);
+				num++;
+			} catch (err) {
+				for (hook of aEach) await hook(state);
+				if (errors.length) errors += '\n';
+				errors += format(test.name, err, name);
+				write(FAIL);
+			}
+		}
+	} finally {
+		state.__test__ = '';
+		for (hook of after) await hook(state);
+		let msg = `  (${num} / ${total})\n`;
+		let skipped = (only.length ? tests.length : 0) + ctx.skips;
+		write(errors.length ? $.red(msg) : $.green(msg));
+		return [errors || true, num, skipped, total];
+	}
+}
+
+let timer;
+function defer() {
+	clearTimeout(timer);
+	timer = setTimeout(exec);
+}
+
+function setup(ctx, name = '') {
+	ctx.state.__test__ = '';
+	ctx.state.__suite__ = name;
+	const test = into(ctx, 'tests');
+	test.before = hook(ctx, 'before');
+	test.before.each = hook(ctx, 'bEach');
+	test.after = hook(ctx, 'after');
+	test.after.each = hook(ctx, 'aEach');
+	test.only = into(ctx, 'only');
+	test.skip = () => { ctx.skips++; };
+	test.run = () => {
+		let copy = { ...ctx };
+		let run = runner.bind(0, copy, name);
+		Object.assign(ctx, context(copy.state));
+		UVU_QUEUE[globalThis.UVU_INDEX || 0].push(run);
+		isCLI || defer();
+	};
+	return test;
+}
+
+const suite = (name = '', state = {}) => setup(context(state), name);
+const test = suite();
+
+async function exec(bail) {
+	let timer = hrtime();
+	let done=0, total=0, skips=0, code=0;
+
+	for (let group of UVU_QUEUE) {
+		if (total) write('\n');
+
+		let name = group.shift();
+		if (name != null) write(FILE(name) + '\n');
+
+		for (let test of group) {
+			let [errs, ran, skip, max] = await test();
+			total += max; done += ran; skips += skip;
+			if (errs.length) {
+				write('\n' + errs + '\n'); code=1;
+				if (bail) return isNode && process.exit(1);
+			}
+		}
+	}
+
+	write('\n  Total:     ' + total);
+	write((code ? $.red : $.green)('\n  Passed:    ' + done));
+	write('\n  Skipped:   ' + (skips ? $.yellow(skips) : skips));
+	write('\n  Duration:  ' + timer() + '\n\n');
+
+	if (isNode) process.exitCode = code;
+}
+
+export { exec, suite, test };


### PR DESCRIPTION
Taken from the README update

---

Junction has a very simple API that doesn't require any programming. To open any resource with Junction, even if it's not configured as the default application, simply use the following URI format `x-junction://$RESOURCE`. For examples

- `x-junction://https://github.com`
- `x-junction://~`
- `x-junction://file:///etc/os-release`
- `x-junction:///etc/os-release`

You can use this in web pages, the terminal, native applications and anything that is able to open URIs.

If Junction is installed - you can test this in the terminal with `xdg-open "x-junction://file:///etc/os-release"` and in the browser with `<a href="x-junction://file:///etc/os-release">Test Junction URI</a>`.