### PR TITLE
Change xdg-settings to xdg-mime

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please note that this may not be respected by all applications but the command `
 <details>
   <summary>Set Junction as default folder opener</summary>
   <code>
-  xdg-settings default re.sonny.Junction.desktop inode/directory
+  xdg-mime default re.sonny.Junction.desktop inode/directory
   </code>
 </details>
 


### PR DESCRIPTION
I think that

```
xdg-settings default re.sonny.Junction.desktop inode/directory
```
need be changed to
```
xdg-mime default re.sonny.Junction.desktop inode/directory
```
![image](https://user-images.githubusercontent.com/60975415/151746483-9647d5a5-4905-40d7-a783-bbc3912553f8.png)

P.S. I dont know how right, but it looks like typo