### PR TITLE
Fix recomended applications in ViewAllButton dialog

### DIFF
--- a/src/AppButton.js
+++ b/src/AppButton.js
@@ -163,7 +163,7 @@ export function RevealInFolderButton({ file, entry, window }) {
   });
 }
 
-export function ViewAllButton({ file, content_type, entry, window }) {
+export function ViewAllButton({ content_type, entry, window }) {
   function onResponse(appChooserDialog, response_id) {
     if (response_id !== Gtk.ResponseType.OK) {
       appChooserDialog.destroy();
@@ -208,8 +208,6 @@ export function ViewAllButton({ file, content_type, entry, window }) {
     appChooserWidget.set_show_recommended(true);
     appChooserWidget.set_show_fallback(true);
     appChooserWidget.set_show_other(true);
-    // FIXME: Search is kinda broken unless this
-    // appChooserWidget.set_show_all(true);
     appChooserDialog.connect("response", onResponse);
     appChooserDialog.show();
   }


### PR DESCRIPTION
Having a lot of browsers, I was frustrated a bit by the limit of 4 introduced recently. However, not a lot of people (except web developers :p) do have that many, so it seems reasonable to keep that limit. I then wanted to use the [...] button (`ViewAllButton`), but I became more frustrated, as keyboard search was not functioning properly.
I noticed that this was the Gtk Widget AppChooserDialog, and that it usually suggest relevant apps on top. But it was not the case when opening URIs :'(

The problem seems to be that AppChooserDialog doesn't suggest recommended apps for dummy files (such as the one passed when junction is called with an URI). So I tried passing the content_type instead, and I saw the recommended apps appear :tada: 

Before:
![Screenshot from 2022-03-14 18-27-51](https://user-images.githubusercontent.com/932583/158231496-60118f5c-bd57-4be4-922a-c1f8e064d07b.png)

After:
![Screenshot from 2022-03-14 18-25-39](https://user-images.githubusercontent.com/932583/158231521-4ba106f6-59fb-4a5d-adb7-008f696dd06d.png)

Note: I would have even preferred to have a `if` branch in case we do call Junction with a real file, but I haven't found a way to check if the `file` is a "DummyFile" or a regular one. (It's one of my first contributions to a Gjs app) So if you know how I could do that, I'd be happy to improve this PR with it :)

Other note: Reading the source, I see that the `AppChooserDialog` dialog uses a `AppChooserWidget`, which needs a `content_type` to be initialized (https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkappchooserdialog.c#L318). This content_type is deduced from the file by `g_file_info_get_content_type` (https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkappchooserdialog.c#L362), which read the attribute `G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE` of the File object (https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gfileinfo.c#L2230). So the best fix could be to be able to set this attribute for the dummy file (created by `Gio.File.new_from_uri`). However, after following its source down this the `get_file_from_uri_internal` (https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gvfs.c#L196), it's seems to be another level of complexity (could be done by setting something like `x-scheme-handler/<the scheme parsed from the URL>`? ...well, maybe thus quick fix is enough time spent on this issue :p).