### PR TITLE
Draft:add custom settings for number of browsers(url handlers) in window an…

### DIFF
--- a/data/re.sonny.Junction.gschema.xml
+++ b/data/re.sonny.Junction.gschema.xml
@@ -4,5 +4,17 @@
     <key name="show-app-names" type="b">
       <default>false</default>
     </key>
-    </schema>
+    <key name="browsers-url-handlers-row-count" type="i">
+      <default>4</default>
+      <summary>Url Handlers count</summary>
+      <description
+      >Number of Browsers visible, when clicking on url</description>
+    </key>
+    <key name="open-window-link-only-once" type="b">
+      <default>false</default>
+      <summary>Open link window only once</summary>
+      <description
+      >Should be the same window with Browsers opened multiple times?</description>
+    </key>
+  </schema>
 </schemalist>

--- a/src/AppButton.js
+++ b/src/AppButton.js
@@ -6,7 +6,7 @@ import { gettext as _ } from "gettext";
 import Xdp from "gi://Xdp";
 
 import { openWithApplication, getIconFilename } from "./util.js";
-import { settings } from "./common.js";
+import {CommonSettings, settings} from "./common.js";
 import Interface from "./AppButton.blp";
 import { promiseTask } from "../troll/src/util.js";
 
@@ -71,6 +71,8 @@ export default function AppButton({ appInfo, content_type, entry, window }) {
       save: true,
     });
     if (close_on_success && success) {
+      console.log("Appbutton2 entry.get_text: "+ entry.get_text());
+      CommonSettings.openedWindows.delete(entry.get_text());
       window.close();
     }
   }
@@ -163,7 +165,7 @@ export function RevealInFolderButton({ file, window }) {
   });
 }
 
-export function ViewAllButton({ content_type, entry, window }) {
+export function ViewAllButton({ content_type, entry, window, resource }) {
   function onResponse(appChooserDialog, response_id) {
     if (response_id !== Gtk.ResponseType.OK) {
       appChooserDialog.destroy();
@@ -183,6 +185,8 @@ export function ViewAllButton({ content_type, entry, window }) {
     }
 
     appChooserDialog.destroy();
+    console.log("Appbutton1 resource: "+ resource);
+    CommonSettings.openedWindows.delete(resource);
     window.close();
   }
 

--- a/src/common.js
+++ b/src/common.js
@@ -4,3 +4,9 @@ export const settings = new Gio.Settings({
   schema_id: "re.sonny.Junction",
   path: "/re/sonny/Junction/",
 });
+
+export class CommonSettings {
+
+   static openedWindows = new Set();
+
+}


### PR DESCRIPTION
Do not merge, open questions remains

Aim of this PR is to prepare environment, to be able to add settings to Junction later

Add some customization to be later appear in settings
- do not open links, when window with this link already exists(FIXME)
- set number of Browsers/Url handlers visible in Chooser window

@sonnyp Could you please help, if you know. How to detect open windows and read them(resource url) inside app?
![image](https://user-images.githubusercontent.com/92012346/216398033-0e72f1ad-e892-4553-ae3e-efe1f415bf3f.png)
