### PR TITLE
Add tooltip to main menus

### DIFF
--- a/src/welcome.blp
+++ b/src/welcome.blp
@@ -12,6 +12,7 @@ Adw.ApplicationWindow welcome {
       MenuButton button_menu {
         menu-model: menu_app;
         icon-name: "open-menu-symbolic";
+        tooltip-text: _("Main Menu");
       }
     }
 

--- a/src/window.blp
+++ b/src/window.blp
@@ -34,6 +34,7 @@ Adw.ApplicationWindow window {
         icon-name: "open-menu-symbolic";
         margin-start: 6;
         valign: center;
+        tooltip-text: _("Main Menu");
 
         styles [
           "circular",


### PR DESCRIPTION
The HIG recommends the use of "Main Menu" for main menu buttons, let's follow that.