### PR TITLE
Open the context menu on Alt-Return

### DIFF
--- a/src/AppButton.js
+++ b/src/AppButton.js
@@ -127,11 +127,17 @@ export default function AppButton({ appInfo, content_type, entry, window }) {
         });
       }
 
-      if (
-        (keyname === "Return" || keyname === "space") &&
-        modifier_state & Gdk.ModifierType.CONTROL_MASK
-      ) {
-        open(false);
+      if (keyname === "Return" || keyname === "space" || /^\d$/.test(keyname)) {
+        if (modifier_state & Gdk.ModifierType.ALT_MASK) {
+          popupActionsMenu({
+            appInfo,
+            popoverMenu,
+            location: entry.get_text(),
+          });
+        } else {
+          open(!(modifier_state & Gdk.ModifierType.CONTROL_MASK));
+        }
+        controller_key.set_state(Gtk.EventSequenceState.CLAIMED);
       }
     },
   );

--- a/src/window.js
+++ b/src/window.js
@@ -93,11 +93,6 @@ export default function Window({ application, file }) {
     button?.grab_focus();
     return !!button;
   });
-  eventController.connect("key-released", (self, keyval) => {
-    const button = getButtonForKeyval(keyval);
-    button?.activate();
-    return !!button;
-  });
   window.add_controller(eventController);
 
   function copyToClipboard() {


### PR DESCRIPTION
Also on Alt-Space but that's usually handled by Mutter.
Also on Alt-Number, and additionally handle Ctrl-Number.

Closes #126

Currently the number keys are handled by the window: pressing one will focus the corresponding tile and releasing the key will activate that tile.
Return and Space are handled by the tile itself.

This change moves responsibility for handling key-released events of number keys from the window to the tiles. The key-pressed event focuses the tile so it can handle the subsequent key-released event. The tiles don't know their corresponding number but since the tile is focused it can assume that the number key was meant for it.