### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/re.sonny.Junction.metainfo.xml
+++ b/data/re.sonny.Junction.metainfo.xml
@@ -167,11 +167,6 @@
     <control>touch</control>
   </recommends>
 
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
-
   <color type="primary" scheme_preference="light">#F8ED9E</color>
   <color type="primary" scheme_preference="dark">#AA7B07</color>
   <custom>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476