### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -22,6 +22,16 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
+# Validate Appdata
+appstreamcli = find_program('appstreamcli', required: false)
+if (appstreamcli.found())
+  test('validate-appdata',
+    appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
+  )
+endif
+
 service_conf = configuration_data()
 service_conf.set('bindir', bindir)
 configure_file(
@@ -30,13 +40,6 @@ configure_file(
   configuration: service_conf,
   install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
 )
-
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate', appstream_file]
-  )
-endif
 
 install_data('re.sonny.Junction.gschema.xml',
   install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')

--- a/data/re.sonny.Junction.metainfo.xml
+++ b/data/re.sonny.Junction.metainfo.xml
@@ -3,7 +3,11 @@
   <id>re.sonny.Junction</id>
   <launchable type="desktop-id">re.sonny.Junction.desktop</launchable>
   <name translatable="no">Junction</name>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Sonny Piers</developer_name>
+  <developer id="github.com">
+    <name translatable="no">Sonny Piers</name>
+  </developer>
   <update_contact>sonnyp@gnome.org</update_contact>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
@@ -32,8 +36,8 @@
   <url type="homepage">https://junction.sonny.re</url>
   <url type="bugtracker">https://junction.sonny.re/feedback</url>
   <url type="donation">https://junction.sonny.re/donate</url>
-  <url type="translate">https://junction.sonny.re/translate</url>
-  <url type="vcs-browser">https://junction.sonny.re/source</url>
+  <url type="translate">https://hosted.weblate.org/engage/junction/</url>
+  <url type="vcs-browser">https://github.com/sonnyp/Junction</url>
   <screenshots>
     <screenshot type="default">
       <image>
@@ -63,7 +67,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="1.8" date="2023-09-23">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Improve portrait layout</li>
           <li>Use GNOME 45</li>
@@ -71,7 +75,7 @@
       </description>
     </release>
     <release version="1.7" date="2023-05-14">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Support multiple lines of options (scroll)</li>
           <li>Support mobile form factors</li>
@@ -82,7 +86,7 @@
       </description>
     </release>
     <release version="1.6" date="2022-10-15">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Use GNOME 43</li>
           <li>Fix the list of recommended applications</li>
@@ -92,7 +96,7 @@
       </description>
     </release>
     <release version="1.5.0" date="2022-01-19">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Add an option "Reveal in Folder" for files</li>
           <li>Reveal document portal file paths</li>
@@ -102,7 +106,7 @@
       </description>
     </release>
     <release version="1.4.0" date="2021-12-23">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Support desktop actions</li>
           <li>Support snap applications</li>
@@ -110,7 +114,7 @@
       </description>
     </release>
     <release version="1.3.0" date="2021-12-12">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Improve design</li>
           <li>New icon</li>
@@ -124,7 +128,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2021-11-14" urgency="high">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fix for applications that do not support URIs</li>
           <li>Add an option to display application names</li>
@@ -140,7 +144,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2021-10-20" urgency="high">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fix for missing applications</li>
           <li>Add a Shortcuts window - accessible with &lt;Ctrl&gt;?</li>
@@ -167,16 +171,12 @@
     <control>touch</control>
   </recommends>
 
+  <branding>
+    <color type="primary" scheme_preference="light">#F8ED9E</color>
+    <color type="primary" scheme_preference="dark">#AA7B07</color>
+  </branding>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
-  </custom>
-
-  <color type="primary" scheme_preference="light">#F8ED9E</color>
-  <color type="primary" scheme_preference="dark">#AA7B07</color>
-  <custom>
-    <value
-      key="GnomeSoftware::key-colors"
-    >[(248, 237, 158), (170, 123, 7)]</value>
+    <value key="GnomeSoftware::key-colors">[(248, 237, 158), (170, 123, 7)]</value>
   </custom>
 </component>

--- a/re.sonny.Junction.json
+++ b/re.sonny.Junction.json
@@ -88,6 +88,7 @@
     {
       "name": "Junction",
       "buildsystem": "meson",
+      "run-tests": true,
       "sources": [
         {
           "type": "dir",


### PR DESCRIPTION
- Use appstreamcli to validate appdata
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Mark release descriptions as untranslatable
- Correct the translation and vcs-browser URLs
- Correct unknown color tag errors
- Remove one of Purism tag to pass appstreamcli validation
- Correct double custom tag error

### data: Mark release descriptions as untranslatable

GNOME automatically excludes release descriptions on Damned Lies
(GNOME Translation Platform). It's a good practice to follow
the GNOME way.

This can streamline the translation process, allowing translators
to focus their efforts on more critical and user-facing aspects
of the application.

### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.