### PR TITLE
Clean up `$XDG_DATA_DIRS`  and adhere to the XDG Base Directory Specification

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S XDG_DATA_DIRS=${XDG_DATA_DIRS}:/run/host/usr/share:/var/lib/snapd/desktop:/var/lib/flatpak/exports/share:${HOME}/.local/share/flatpak/exports/share gjs -m
+#!/usr/bin/env -S XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}:/run/host/usr/share:/var/lib/snapd/desktop:/var/lib/flatpak/exports/share:${HOME}/.local/share/flatpak/exports/share gjs -m
 
 import { exit, programArgs, programInvocationName } from "system";
 import GLib from "gi://GLib";

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}:/run/host/usr/share:/var/lib/snapd/desktop:/var/lib/flatpak/exports/share:${HOME}/.local/share/flatpak/exports/share gjs -m
+#!/usr/bin/env -S XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}:/run/host/usr/share gjs -m
 
 import { exit, programArgs, programInvocationName } from "system";
 import GLib from "gi://GLib";


### PR DESCRIPTION
The first commit fixes a startup error (#115), when `$XDG_DATA_DIRS` is not defined and thus gets set incorrectly 
to
`:/run/host/usr/share:/var/lib/snapd/desktop:/var/lib/flatpak/exports/share:${HOME}/.local/share/flatpak/exports/share` while the XDG Base Directory Specification [states](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables):
>  If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used.


The second commit removes entries from `$XDG_DATA_DIRS` that Snapd and Flatpak set themselves already.