### PR TITLE
Add http and https MIME types in desktop entry

### DIFF
--- a/data/re.sonny.Junction.desktop
+++ b/data/re.sonny.Junction.desktop
@@ -3,7 +3,7 @@
 Name=Junction
 Comment=Application chooser
 Exec=re.sonny.Junction %U
-MimeType=x-scheme-handler/x-junction
+MimeType=x-scheme-handler/x-junction;x-scheme-handler/https;x-scheme-handler/http
 Terminal=false
 Type=Application
 Categories=Settings;System;Utility;GNOME;GTK;


### PR DESCRIPTION
This makes it selectable in default app selector in GNOME Settings.