### PR TITLE
Use appstream for metainfo validation test

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -31,10 +31,10 @@ configure_file(
   install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file]
   )
 endif
 


### PR DESCRIPTION
appstream-glib is under heavy maintenance mode and recommends using appstream instead.