### PR TITLE
Set color scheme later

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -27,7 +27,9 @@ export default function Application() {
     );
   }
 
-  Adw.StyleManager.get_default().set_color_scheme(Adw.ColorScheme.FORCE_DARK);
+  application.connect("startup", () => {
+    Adw.StyleManager.get_default().set_color_scheme(Adw.ColorScheme.FORCE_DARK);
+  });
 
   // FIXME: Cannot deal with mailto:, xmpp:, ... URIs
   // GFile mess the URI if the scheme separator does not include "//" like about:blank or mailto:foo@bar.com


### PR DESCRIPTION
GTK 4.18 no longer allow to create displays before GDK has been initialized. Therefore the style manager cannot be initialized before that, as it causing an abort.

See details: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7836