### PR TITLE
Update window.js to fix duplicate entries

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -147,10 +147,7 @@ function getApplications(content_type) {
   const seen = new Set();
 
   let applications = Gio.AppInfo.get_recommended_for_type(content_type);
-  console.log("Recommended:", applications.map(a => a.get_id()));
-
   if (!applications || applications.length === 0) {
-    console.log("No recommended apps — falling back to get_all()");
     applications = Gio.AppInfo.get_all().filter((appInfo) => {
       return (
         appInfo.should_show() &&


### PR DESCRIPTION
Rewrote getApplications() to:

- Use recommended apps when available via `Gio.AppInfo.get_recommended_for_type()`
- Fallback to a full app scan using `Gio.AppInfo.get_all()` if recommendations are empty
- Filter out hidden or excluded apps
- Dedupe entries by executable path to avoid duplicate browsers

This helps resolve issue #178  where browsers appear duplicated (such as Brave and Chrome).

This is my first PR for Junction, if I am not doing something right, please let me know! 