### PR TITLE
metainfo: Fix validation

### DIFF
--- a/data/re.sonny.Junction.metainfo.xml
+++ b/data/re.sonny.Junction.metainfo.xml
@@ -150,8 +150,9 @@
       </description>
     </release>
     <release version="1.0.0" date="2021-10-16">
-      <description
-      >This is the first release of Junction. We hope you like it.</description>
+      <description>
+        <p>This is the first release of Junction. We hope you like it.</p>
+      </description>
     </release>
   </releases>
   <kudos>


### PR DESCRIPTION
All text must be in paragraphs or list item elements - text that contained directly in a description element is not permitted.

Reference:
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description