### PR TITLE
Filter out applications marked as NoDisplay in .desktop entry

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -146,6 +146,8 @@ const excluded_apps = [
 function getApplications(content_type) {
   const applications = Gio.AppInfo.get_recommended_for_type(content_type);
   return applications.filter((appInfo) => {
-    return !excluded_apps.includes(appInfo.get_id());
+    const id = appInfo.get_id();
+    const noDisplay = Gio.DesktopAppInfo.new(id)?.get_boolean("NoDisplay") ?? false;
+    return !excluded_apps.includes(id) && !noDisplay;
   });
 }


### PR DESCRIPTION
Fixes issue #178 that happens with Google Chrome too.