### PR TITLE
fix: detect system flatpak applications in sandboxed environment

### DIFF
--- a/src/desktop.js
+++ b/src/desktop.js
@@ -162,6 +162,13 @@ export async function loadApplications() {
     );
   }
 
+  // Allow users to add custom paths via environment variable
+  const customPaths = GLib.getenv("JUNCTION_APPLICATION_PATHS");
+  if (customPaths) {
+    console.debug(`Adding custom application paths from JUNCTION_APPLICATION_PATHS: ${customPaths}`);
+    paths.push(...customPaths.split(":").filter((p) => p.length > 0));
+  }
+
   console.debug(`Scanning application directories: ${paths.join(", ")}`);
   applications = (
     await Promise.all(paths.map((path) => getApplicationsForDir(path)))


### PR DESCRIPTION
When running as a sandboxed flatpak, Junction was only checking /run/host paths for system applications. However, some paths like /var/lib/flatpak/exports/share/applications/ are bound directly at their original location in the sandbox, not under /run/host/.

This fix checks both /run/host paths (for standard sandbox mounts) AND the direct system paths, ensuring all installed applications are discovered regardless of how they're bind-mounted.

This resolves the issue where system flatpak-installed browsers and other applications were not showing up in Junction.

Added debug logging to help users troubleshoot application discovery issues. 
Also improved error handling to gracefully handle permission denied and other IO errors, and to mitigate broken enumeration when path returns error.