### PR TITLE
Give each menu button its own popover

### DIFF
--- a/src/window.blp
+++ b/src/window.blp
@@ -27,7 +27,7 @@ Adw.ApplicationWindow window {
     Adw.HeaderBar header_bar {
       [start]
       MenuButton {
-        popover: menu_popover;
+        menu-model: menu_model;
         icon-name: "open-menu-symbolic";
         tooltip-text: _("Main Menu");
         valign: center;
@@ -60,7 +60,7 @@ Adw.ApplicationWindow window {
       styles ["bar"]
 
       MenuButton button_menu_bottom {
-        popover: menu_popover;
+        menu-model: menu_model;
         icon-name: "open-menu-symbolic";
         tooltip-text: _("Main Menu");
         valign: center;
@@ -80,11 +80,6 @@ Adw.ApplicationWindow window {
       }
     }
   };
-}
-
-PopoverMenu menu_popover {
-  menu-model: menu_model;
-  halign: start;
 }
 
 menu menu_model {


### PR DESCRIPTION
Split out of #218 as requested.

Both `MenuButton`s pointed at a single shared `PopoverMenu` instance. A `GtkPopover` can only have one parent, so GTK reparented it and logged `gtk_widget_set_parent` criticals on every launch. On Plasma the visible symptoms were a stray arrow pointing at the hidden header button, and the menu opening by itself.

Each button now uses `menu-model:` and gets its own correctly parented popover from the same `GMenu`. The criticals go from one per launch to zero.